### PR TITLE
fix: fix display mode matching for mpv backend

### DIFF
--- a/plugin/contents/ui/backend/Mpv.qml
+++ b/plugin/contents/ui/backend/Mpv.qml
@@ -10,7 +10,7 @@ Item{
     
     onDisplayModeChanged: {
         let value = 0.0;
-        if(videoItem.displayMode == Common.DisplayMode.Scale)
+        if(videoItem.displayMode == Common.DisplayMode.Crop)
             value = 1.0;
         else if(videoItem.displayMode == Common.DisplayMode.Aspect)
             value = 0.0;


### PR DESCRIPTION
As I think it truly works and what mpv option "panscan" is meaning [(mpv options)](https://github.com/mpv-player/mpv/blob/master/DOCS/man/options.rst).