### PR TITLE
CMake minimum version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A wallpaper plugin integrating [wallpaper engine](https://store.steampowered.com
   - Mouse long press (to enter panel edit mode) is broken on desktop.
 - Support **scene(2d)**,**video**,**web** wallpaper types
 - Requires *Wallpaper Engine* installed on steam
-- Requires qt 5.13+ for playing video(no mpv), or mpv instead  
+- Requires [CMake 3.16+](#dependencies)
+- Requires [qt 5.13+](#dependencies) for playing video(no mpv), or [mpv](#dependencies) instead  
 
 ## Install
 #### Dependencies


### PR DESCRIPTION
A warning encountered by the new `cmake .. -DUSE_PLASMAPKG=ON` build method:
```
CMake Warning (dev) at /usr/share/ECM/modules/ECMFindModuleHelpers.cmake:112 (message):
  Your project should require at least CMake 3.16.0 to use FindKF5.cmake
Call Stack (most recent call first):
  /usr/share/ECM/find-modules/FindKF5.cmake:30 (ecm_find_package_version_check)
  CMakeLists.txt:31 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
This seems benign so long as users have met the warning's minimum requirements. I don't know how FindKF5.cmake will react to a CMake version lower than 3.16. Simply keeping all packages up to date was sufficient for me. However, CMake 3.16+ should be added to the current requirements alongside QT 5.13+ and mpv to avoid confusion. Simply changing the CMake minimum version as in this PR resolved the warning.
Compiled latest with `rm -R build/ && mkdir build && cd build && cmake .. -DUSE_PLASMAPKG=ON && make && sudo make install`.
Was compiling with `cd build && cmake && make && sudo make install && cd ../.. && plasmapkg2 -u wallpaper-engine-kde-plugin/plugin` before latest changes.
Thanks for improving installation.