### PR TITLE
Prevent overlapping text on the tab bar

### DIFF
--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -110,15 +110,16 @@ ColumnLayout {
 
     PlasmaComponents3.TabBar {
         id: bar
-        implicitWidth: height * 7
-        //currentTab
         PlasmaComponents3.TabButton {
+            id: tabBut
             text: qsTr("Wallpapers")
         }
         PlasmaComponents3.TabButton {
+            width: tabBut.width
             text: qsTr("Settings")
         }
         PlasmaComponents3.TabButton {
+            width: tabBut.width
             text: qsTr("About")
         }
     }

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -110,7 +110,7 @@ ColumnLayout {
 
     PlasmaComponents3.TabBar {
         id: bar
-        implicitWidth: height * 15
+        implicitWidth: height * 7
         //currentTab
         PlasmaComponents3.TabButton {
             text: qsTr("Wallpapers")

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -110,6 +110,7 @@ ColumnLayout {
 
     PlasmaComponents3.TabBar {
         id: bar
+        implicitWidth: height * 2.125
         //currentTab
         PlasmaComponents3.TabButton {
             text: qsTr("Wallpapers")

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -110,7 +110,7 @@ ColumnLayout {
 
     PlasmaComponents3.TabBar {
         id: bar
-        implicitWidth: height * 2.125
+        implicitWidth: height * 15
         //currentTab
         PlasmaComponents3.TabButton {
             text: qsTr("Wallpapers")


### PR DESCRIPTION
This happened to me after updating:
![Screenshot_20211128_031452](https://user-images.githubusercontent.com/92762322/143727672-06d84f84-179a-4b58-8922-9596ff2674ca.png)
I think it's the fault of my last commit - I didn't think that it wouldn't fit and disregarded width.

I added an implicitWidth to the TabBar to prevent it from happening again and it seems to work perfectly now. I am not sure if it was the fault of some other property in the code. If it is, feel free can change the width there - this is just a small fix because it annoyed me