### PR TITLE
readme: fix kde restart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ sudo make install
 
 ### Restart KDE
 You need to restart KDE(re-login) after **reinstalling the plugin**  
-You can also try using: `kquitapp5 plasmashell && kstart5 plasmashell`  
+You can also try using: `kquitapp5 plasmashell && kstart5 plasmashell &>/dev/null`  
 
 ## Support Status
 ### Scene:


### PR DESCRIPTION
This pr updates the command for restarting KDE to include a `&>/dev/null` at the end. If you don't do that, you can encounter some very weird problems because some programs can't find a standard output.