### PR TITLE
Add required library to #includes for GCC 12

### DIFF
--- a/src/backend_scene/wallpaper/Utils/span.hpp
+++ b/src/backend_scene/wallpaper/Utils/span.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <algorithm>
+#include <vector>
 
 template <typename T>
 class Span {


### PR DESCRIPTION
Fixes GCC 12 compilation

a208004af06ea696dcbb1aebc335e3276f2c72a8 seems to have caught another instance of something missing.