### PR TITLE
fix: use theme color in config & wallpaperpage

### DIFF
--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -133,7 +133,7 @@ ColumnLayout {
         PlasmaComponents.TabButton {
             height: font.pixelSize
             Text{
-                text: "Backgrounds"
+                text: "Wallpapers"
                 color: Theme.textColor
                 anchors.centerIn: parent
             }

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -129,17 +129,30 @@ ColumnLayout {
     PlasmaComponents.TabBar {
         id: bar
         implicitWidth: font.pixelSize*8 * 3
+        implicitHeight: font.pixelSize
         PlasmaComponents.TabButton {
-            text: 'Wallpapers'
-            display: PlasmaComponents.TabButton.TextOnly
+            height: font.pixelSize
+            Text{
+                text: "Backgrounds"
+                color: Theme.textColor
+                anchors.centerIn: parent
+            }
         }
         PlasmaComponents.TabButton {
-            text: 'Settings'
-            display: PlasmaComponents.TabButton.TextOnly
+            height: font.pixelSize
+            Text{
+                text: "Settings"
+                color: Theme.textColor
+                anchors.centerIn: parent
+            }
         }
         PlasmaComponents.TabButton {
-            text: 'About'
-            display: PlasmaComponents.TabButton.TextOnly
+            height: font.pixelSize
+            Text{
+                text: "About"
+                color: Theme.textColor
+                anchors.centerIn: parent
+            }
         }
     }
 

--- a/plugin/contents/ui/page/WallpaperPage.qml
+++ b/plugin/contents/ui/page/WallpaperPage.qml
@@ -729,6 +729,7 @@ RowLayout {
 
                     visible: false
                     text: ''
+                    color: Theme.textColor
                     readonly property bool _set_text: {
                         const path = Common.getWpModelProjectPath(right_content.wpmodel);
                         if(path) {


### PR DESCRIPTION
Currently the color of some text in Config/Wallpaperpage doesn't use `Theme.textcolor`.

If the user uses white system theme, the original text can hardly be recognized.