### PR TITLE
Fix build on openSUSE TW(GCC 13 Distros)

### DIFF
--- a/src/backend_scene/third_party/vk_mem_alloc.h
+++ b/src/backend_scene/third_party/vk_mem_alloc.h
@@ -2559,6 +2559,7 @@ remove them if not needed.
     #include <cassert> // for assert
     #include <algorithm> // for min, max
     #include <mutex>
+    #include <cstdio>
 #else
     #include VMA_CONFIGURATION_USER_INCLUDES_H
 #endif


### PR DESCRIPTION
The plugin wasn't building on openSUSE because it missed an include. This PR adds it.

Related to #286