### PR TITLE
Adapt to Wallpaper Engine 2.3 color uniform name

### DIFF
--- a/src/backend_scene/src/WPSceneParser.cpp
+++ b/src/backend_scene/src/WPSceneParser.cpp
@@ -603,8 +603,12 @@ void ParseImageObj(ParseContext& context, wpscene::WPImageObject& img_obj) {
             }
         }
 
-        baseConstSvs["g_Alpha"]      = wpimgobj.alpha;
-        baseConstSvs["g_Color"]      = wpimgobj.color;
+        baseConstSvs["g_Color4"]     = std::array<float, 4> {
+            wpimgobj.color[0],
+            wpimgobj.color[1],
+            wpimgobj.color[2],
+            1.0f
+        };
         baseConstSvs["g_UserAlpha"]  = wpimgobj.alpha;
         baseConstSvs["g_Brightness"] = wpimgobj.brightness;
 


### PR DESCRIPTION
Replaces `g_Color` with `g_Color4`, as suggested in #327. Seems to work fine on my end.

Suggestions welcome. (Some cleanup possibly?)