### PR TITLE
Pause when PC is on battery power

### DIFF
--- a/plugin/contents/config/main.xml
+++ b/plugin/contents/config/main.xml
@@ -34,8 +34,8 @@
       <label>Filter By Screen</label>
       <default>true</default>
     </entry>
-    <entry name="PauseAcPlugin" type="Bool">
-      <label>Pause Ac Plugin</label>
+    <entry name="PauseOnBatPower" type="Bool">
+      <label>Pause when PC is on battery power</label>
       <default>false</default>
     </entry>
     <entry name="PauseBatPercent" type="Int">

--- a/plugin/contents/ui/PowerSource.qml
+++ b/plugin/contents/ui/PowerSource.qml
@@ -4,18 +4,18 @@ import org.kde.plasma.core 2.0 as PlasmaCore
 
 Item {
 	id: root
-    readonly property alias pm_data: pm_source.data
+	readonly property alias pm_data: pm_source.data
 
-    readonly property bool   st_battery_has: pm_data['Battery']['Has Battery']
+	readonly property bool   st_battery_has: pm_data['Battery']['Has Battery']
 	readonly property string st_battery_state: pm_data['Battery']['State']
-    readonly property int    st_battery_percent: pm_data['Battery']['Percent']
+	readonly property int    st_battery_percent: pm_data['Battery']['Percent']
 
 	// https://github.com/KDE/plasma-workspace/blob/master/dataengines/powermanagement/powermanagementengine.h
 	// https://github.com/KDE/plasma-workspace/blob/master/dataengines/powermanagement/powermanagementengine.cpp
 	PlasmaCore.DataSource {
 		id: pm_source
 		engine: 'powermanagement'
-		connectedSources: ['Battery', 'AC Adapter'] // basicSourceNames == ["Battery", "AC Adapter", "Sleep States", "PowerDevil", "Inhibitions"]
+		connectedSources: ['Battery'] // basicSourceNames == ["Battery", "AC Adapter", "Sleep States", "PowerDevil", "Inhibitions"]
 		function log() {
 			for (var i = 0; i < pm_source.sources.length; i++) {
 				var sourceName = pm_source.sources[i]
@@ -26,5 +26,5 @@ Item {
 			}
 		}
 	}
-    // Component.onCompleted: pm_source.log()
+	// Component.onCompleted: pm_source.log()
 }

--- a/plugin/contents/ui/PowerSource.qml
+++ b/plugin/contents/ui/PowerSource.qml
@@ -6,9 +6,9 @@ Item {
 	id: root
     readonly property alias pm_data: pm_source.data
 
-    readonly property bool st_ac_plugin_in: pm_data['AC Adapter']['Plugged in']
-    readonly property bool st_battery_has: pm_data['Battery']['Has Battery']
-    readonly property int  st_battery_percent: pm_data['Battery']['Percent']
+    readonly property bool   st_battery_has: pm_data['Battery']['Has Battery']
+	readonly property string st_battery_state: pm_data['Battery']['State']
+    readonly property int    st_battery_percent: pm_data['Battery']['Percent']
 
 	// https://github.com/KDE/plasma-workspace/blob/master/dataengines/powermanagement/powermanagementengine.h
 	// https://github.com/KDE/plasma-workspace/blob/master/dataengines/powermanagement/powermanagementengine.cpp

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -28,7 +28,7 @@ ColumnLayout {
     property alias  cfg_SwitchTimer:         settingPage.cfg_SwitchTimer
     property alias  cfg_RandomizeWallpaper:  settingPage.cfg_RandomizeWallpaper
     property alias  cfg_PauseFilterByScreen: settingPage.cfg_PauseFilterByScreen
-    property alias  cfg_PauseAcPlugin:       settingPage.cfg_PauseAcPlugin
+    property alias  cfg_PauseOnBatPower:     settingPage.cfg_PauseOnBatPower
     property alias  cfg_PauseBatPercent:     settingPage.cfg_PauseBatPercent
     property int    cfg_DisplayMode
     property int    cfg_PauseMode

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -20,8 +20,8 @@ Rectangle {
     property bool   mouseInput: wallpaper.configuration.MouseInput
     property bool   mpvStats: wallpaper.configuration.MpvStats
 
-    property bool   pauseAcPlugin: wallpaper.configuration.PauseAcPlugin
-    property int   pauseBatPercent: wallpaper.configuration.PauseBatPercent
+    property bool   pauseOnBatPower: wallpaper.configuration.PauseOnBatPower
+    property int    pauseBatPercent: wallpaper.configuration.PauseBatPercent
 
     
     property var curOpt: ({})
@@ -167,7 +167,7 @@ Rectangle {
     PowerSource {
         id: powerSource
         readonly property bool reqPause: {
-            (background.pauseAcPlugin && !st_ac_plugin_in) ||
+            (background.pauseOnBatPower && (st_battery_state == 'NoCharge' || st_battery_state == 'Discharging')) ||
             (background.pauseBatPercent !== 0 && st_battery_has && st_battery_percent < background.pauseBatPercent)
         }
     }

--- a/plugin/contents/ui/page/SettingPage.qml
+++ b/plugin/contents/ui/page/SettingPage.qml
@@ -24,7 +24,7 @@ Flickable {
     property alias cfg_RandomizeWallpaper: ckbox_randomizeWallpaper.checked
     property alias cfg_PauseFilterByScreen: ckbox_pauseFilterByScreen.checked
 
-    property alias cfg_PauseAcPlugin: ckbox_pauseAcPlugin.checked
+    property alias cfg_PauseOnBatPower: chkbox_pauseOnBatPower.checked
     property alias cfg_PauseBatPercent: spin_pauseBatPercent.value
 
 
@@ -98,10 +98,10 @@ Flickable {
                 }
             }
             OptionItem {
-                text: 'Pause if AC adapter not plugged in'
+                text: 'Pause if PC is on battery power'
                 text_color: Theme.textColor
                 actor: Switch {
-                    id: ckbox_pauseAcPlugin
+                    id: chkbox_pauseOnBatPower
                 }
             }
             OptionItem {


### PR DESCRIPTION
AC adapter may be plugged in while its power is not enough to charge the battery. A better option is to pause when battery is discharging.
