### PR TITLE
Add image alpha to `g_Color4`

### DIFF
--- a/src/backend_scene/src/WPSceneParser.cpp
+++ b/src/backend_scene/src/WPSceneParser.cpp
@@ -607,7 +607,7 @@ void ParseImageObj(ParseContext& context, wpscene::WPImageObject& img_obj) {
             wpimgobj.color[0],
             wpimgobj.color[1],
             wpimgobj.color[2],
-            1.0f
+            wpimgobj.alpha
         };
         baseConstSvs["g_UserAlpha"]  = wpimgobj.alpha;
         baseConstSvs["g_Brightness"] = wpimgobj.brightness;


### PR DESCRIPTION
The opacity/alpha property isn't passed to shader correctly, causing some scene not rendering correctly,
e.g. [Starry Sky (2593802083)](https://steamcommunity.com/sharedfiles/filedetails/?id=2593802083)

Closes: #342
Fixes: c00b244 ("add alpha to color4")

Related: #327 #331

Maybe need more testing to see if this breaks other scenes.