### PR TITLE
Fixed a typo causing python unable to find execute pyext.py

### DIFF
--- a/plugin/contents/ui/Pyext.qml
+++ b/plugin/contents/ui/Pyext.qml
@@ -7,7 +7,7 @@ import "js/jsonrpc.mjs" as Jsonrpc
 
 Item {
     id: root
-    readonly property string file: "plasma/wallpapers/com.github.casout.wallpaperEngineKde/contents/pyext.py"
+    readonly property string file: "plasma/wallpapers/com.github.catsout.wallpaperEngineKde/contents/pyext.py"
     readonly property string source: {
         const sh = [
             `EXT=${file}`,


### PR DESCRIPTION
When using

```sh
cmake --build build --target install_pkg
```

It install into $HOME/.local/share/plasma/wallpapers/com.github.catsout.WallpaperEngineKde/

But in [Pyext.qml](https://github.com/catsout/wallpaper-engine-kde-plugin/blob/qt6/plugin/contents/ui/Pyext.qml) it's trying to execute [pyext.py](https://github.com/catsout/wallpaper-engine-kde-plugin/blob/qt6/plugin/contents/pyext.py) with
"plasma/wallpapers/com.github.casout.wallpaperEngineKde/contents/pyext.py".
So the path doesn't match. Causing a no such file or directory error with python.