### PR TITLE
Fix auto pause in WindowModel

### DIFF
--- a/plugin/contents/ui/WindowModel.qml
+++ b/plugin/contents/ui/WindowModel.qml
@@ -97,6 +97,9 @@ Item {
     TaskManager.ActivityInfo { 
         id: activityInfo 
         onCurrentActivityChanged: virtualDesktopInfo.onCurrentDesktopChanged();
+        Component.onCompleted: {
+            wModel.activity = this.currentActivity;
+        }
     }
 
     TaskManager.VirtualDesktopInfo { 

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -160,7 +160,6 @@ Rectangle {
     WindowModel {
         id: windowModel
         screenGeometry: wallpaper.parent.screenGeometry
-        activity: wallpaper.parent.activity ?? ''
         filterByScreen: wallpaper.configuration.PauseFilterByScreen
         modePlay: wallpaper.configuration.PauseMode
         resumeTime: wallpaper.configuration.ResumeTime


### PR DESCRIPTION
In Plasma 6, the activity of wallpaper seems not accessible by `wallpaper.parent.activity`, then auto pause with maximized/focused window fails because it filters window with activity id.

This patch fixes auto pause by setting `wModel.activity`, using same method as `wModel.desktop`.

Please check whether this can fix auto pause in your environment @AngelSherry  @zjypls