### PR TITLE
Fix Mouse Hover on Scene Wallpapers

### DIFF
--- a/plugin/contents/ui/backend/Scene.qml
+++ b/plugin/contents/ui/backend/Scene.qml
@@ -36,8 +36,8 @@ Item{
         }
 
         Connections {
-            ignoreUnknownSignals: true
-            onFirstFrame: {
+            target: player
+            function onFirstFrame() {
                 background.sig_backendFirstFrame('scene');
             }
         }

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -60,8 +60,8 @@ Rectangle {
     property string wallpaperPath
     property string wallpaperType
 
-    signal sig_backendFirstFrame(string backname);
-    onSig_backendFirstFrame: {
+    signal sig_backendFirstFrame(string backname)
+    function onBackendFirstFrame(backname) {
         console.error(`backend ${backname} first frame`);
         if (wallpaper.hasOwnProperty('accentColor'))
             wallpaper.accentColorChanged();
@@ -113,8 +113,8 @@ Rectangle {
         interval: 2000
         property int tryTimes: 0
         onTriggered: {
-            tryTimes++; 
-            if(tryTimes >= 10 || !background.hasLib || !this.mouseInput) return;
+            tryTimes++;
+            if(tryTimes >= 10 || !background.hasLib || !background.mouseInput) return;
             if(background.mouseHooker) return;
             background.hookMouse();
         }

--- a/src/MouseGrabber.cpp
+++ b/src/MouseGrabber.cpp
@@ -2,6 +2,8 @@
 #include <iostream>
 #include <QLoggingCategory>
 #include <QCoreApplication>
+#include <QHoverEvent>
+#include <QMouseEvent>
 
 using namespace wekde;
 
@@ -42,22 +44,22 @@ void MouseGrabber::sendEvent(QObject* target, QEvent* event) {
 
 void MouseGrabber::sendMouseEvent(QMouseEvent* event) {
     if (m_target) {
-        QMouseEvent temp = QMouseEvent(event->type(),
-                                       mapToItem(m_target, event->localPos()),
-                                       event->screenPos(),
-                                       event->button(),
-                                       event->buttons(),
-                                       event->modifiers());
+        QMouseEvent temp(event->type(),
+                         mapToItem(m_target, event->localPos()),
+                         event->screenPos(),
+                         event->button(),
+                         event->buttons(),
+                         event->modifiers());
         QCoreApplication::sendEvent(m_target, &temp);
     }
 }
 
 void MouseGrabber::sendHoverEvent(QHoverEvent* event) {
     if (m_target) {
-        QHoverEvent temp = QHoverEvent(event->type(),
-                                       mapToItem(m_target, event->posF()),
-                                       mapToItem(m_target, event->oldPosF()),
-                                       event->modifiers());
+        QHoverEvent temp(event->type(),
+                         mapToItem(m_target, event->posF()),
+                         mapToItem(m_target, event->oldPosF()),
+                         event->modifiers());
         QCoreApplication::sendEvent(m_target, &temp);
     }
 }

--- a/src/MouseGrabber.hpp
+++ b/src/MouseGrabber.hpp
@@ -15,11 +15,11 @@ class MouseGrabber : public QQuickItem
 	Q_PROPERTY(QQuickItem* target READ target WRITE setTarget NOTIFY targetChanged)
 
 public:
-    MouseGrabber(QQuickItem *parent = 0);
-    virtual ~MouseGrabber() {};
+	MouseGrabber(QQuickItem *parent = nullptr);
+	virtual ~MouseGrabber() override {};
 
 	bool forceCapture() const;
-	QQuickItem* target() const;	
+	QQuickItem* target() const; 
 
 	void setForceCapture(bool);
 	void setTarget(QQuickItem*);
@@ -27,12 +27,12 @@ public:
 	Q_INVOKABLE void sendEvent(QObject*, QEvent*);
 
 protected:
-	void mouseUngrabEvent();
-	void mousePressEvent(QMouseEvent*);
-	void mouseMoveEvent(QMouseEvent*);
-	void mouseReleaseEvent(QMouseEvent *);
-    void mouseDoubleClickEvent(QMouseEvent *);
-    void hoverMoveEvent(QHoverEvent *);
+	void mouseUngrabEvent() override;
+	void mousePressEvent(QMouseEvent*) override;
+	void mouseMoveEvent(QMouseEvent*) override;
+	void mouseReleaseEvent(QMouseEvent *) override;
+	void mouseDoubleClickEvent(QMouseEvent *) override;
+	void hoverMoveEvent(QHoverEvent *) override;
 
 signals:
 	void forceCaptureChanged();


### PR DESCRIPTION
Hello! After some testing I managed to find and fix the issue with mouse hover on the QT6 branch using Plasma 6.

System Specs:

- Plasma 6.0.5
- QMake version 3.1
- Using Qt version 6.7.1

The main problem was that `this.mouseInput` was being used instead of `background.mouseInput`, causing the `Timer` to always return without grabbing the mouse correctly.

Other changes I made:
* Added includes to MouseGrabber and simplified some logic
* Changed a Scene.qml `Connection` that was using deprecated syntax
* Forced `override` in all MouseGrabber functions. I'm not sure if it's needed since it was added before I detected the problem with `this.mouseInput`