### PR TITLE
Added playlists as a filterable property. Should solve #128

### DIFF
--- a/plugin/contents/ui/Common.qml
+++ b/plugin/contents/ui/Common.qml
@@ -39,7 +39,8 @@ QtObject {
         type: "unknown",
         contentrating: "Everyone",
         tags: [],
-        favor: false
+        favor: false,
+        playlists: []
     })
 
     function wpitemFromQtObject(qobj) {
@@ -86,7 +87,33 @@ QtObject {
         ListElement { text: "Television";   type:"tags";          key:"Television";    def: 1}
         ListElement { text: "Vehicle";      type:"tags";          key:"Vehicle";       def: 1}
         ListElement { text: "Unspecified";  type:"tags";          key:"Unspecified";   def: 1}
+        ListElement { text: "PLAYLIST";     type:"_nocheck";      key:"";              def: 1}
 
+        // need to be able to lock the filterModel because when settings are being applied to multiple screens simultaneously,
+        // the filtermodel can be modified by multiple threads at the same time. This can lead to having excess playlist entries, which will cause
+        // the filter value to be rejected by the getValueArray function for being shorter than the numebr of filter elements, causing it to drop 
+        // the filter value and use the default value instead.This is particularly problematic when using the randomizer timer across multiple screens.
+        property var lock: ({
+            locked : false,
+            lock_resolvers: [],
+            lock: function() {
+                return new Promise((resolve, reject) => {
+                    if(!this.locked) {
+                        this.locked = true;
+                        resolve();
+                    } else {
+                        this.lock_resolvers.push(resolve);
+                    }
+                });            
+            },
+            release: function() {
+                if(this.lock_resolvers.length > 0) {
+                    this.lock_resolvers.shift()();
+                } else {
+                    this.locked = false;
+                }
+            }
+        })
 
         function map(func) {
             const arr = [];
@@ -107,6 +134,7 @@ QtObject {
         function genFilter(filters) {
             const typeF = {};
             const noTags = new Set();
+            const playlists = new Set();
             let onlyFavor = false;
             filters.forEach((el) => {
                 if(el.type === "type") 
@@ -117,6 +145,11 @@ QtObject {
                     onlyFavor = el.value;
                 else if(el.type === "tags") {
                     if(!el.value) noTags.add(el.key)
+                }
+                else if(el.type === "playlist") {
+                    if(el.value) {
+                        playlists.add(el.key);
+                    }                    
                 }
             });
 
@@ -131,8 +164,17 @@ QtObject {
                 }
                 return true;
             }
+            const checkPlaylists = (el) => {
+                if(playlists.size === 0) return true;
+                for(let i=0; i < el.playlists.length;i++) {
+                    if(playlists.has(el.playlists[i].key)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
             return (el) => {
-                return checkType(el) && checkFavor(el) && checkContentrating(el) && checkNoTags(el);
+                return checkType(el) && checkFavor(el) && checkContentrating(el) && checkNoTags(el) && checkPlaylists(el);
             }
         }
     }
@@ -167,6 +209,9 @@ QtObject {
     }
     function getAssetsPath(steamLibrary) {
         return steamLibrary + "/steamapps/common/wallpaper_engine/assets";
+    }
+    function getGlobalConfigPath(steamLibrary) {
+        return steamLibrary + "/steamapps/common/wallpaper_engine/config.json";
     }
     function getWorkshopUrl(workshopid) {
         return "https://steamcommunity.com/sharedfiles/filedetails/?id=" + workshopid;

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -105,6 +105,7 @@ ColumnLayout {
     WallpaperListModel {
         id: wpListModel
         workshopDirs: Common.getProjectDirs(cfg_SteamLibraryPath)
+        globalConfigPath: Common.getGlobalConfigPath(cfg_SteamLibraryPath)
         filterStr: cfg_FilterStr
         sortMode: cfg_SortMode
         initItemOp: (item) => {

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -147,11 +147,6 @@ Rectangle {
                         anchors.fill: parent
                     }
             `, screenGrid);
-            /*
-            console.error(Common.genItemListStr(Window.contentItem, "  ", function(item) {
-                return `${item} {z: ${item.z}, w: ${item.width}, h: ${item.height}}`;
-            }));
-            */
             return true;
        }
        return false;
@@ -180,6 +175,7 @@ Rectangle {
         id: wpListModel
         enabled: background.randomizeWallpaper
         workshopDirs: Common.getProjectDirs(background.steamlibrary)
+        globalConfigPath: Common.getGlobalConfigPath(background.steamlibrary)
         filterStr: background.filterStr
         initItemOp: (item) => {
             if(!background.customConf) return;

--- a/plugin/contents/ui/page/WallpaperPage.qml
+++ b/plugin/contents/ui/page/WallpaperPage.qml
@@ -303,7 +303,7 @@ RowLayout {
                 onAccepted: {
                     const path = Utils.trimCharR(wpDialog.selectedFolder.toString(), '/');
                     cfg_SteamLibraryPath = path;
-                    wpListModel.refresh();
+                    return wpListModel.refresh();
                 }
             }
         }
@@ -475,10 +475,15 @@ RowLayout {
                     readonly property bool _set_model: {
                         const wpmodel = right_content.wpmodel;
                         const tags = right_content.wpmodel.tags;
+                        const playlists = right_content.wpmodel.playlists;
                         const _model = this.model;
                         _model.clear();
                         for(const i of Array(tags.length).keys())
                             _model.append(tags.get(i));
+                        for(const i of Array(playlists.length).keys()){
+                            var playlist = playlists.get(i);
+                            if(playlist != null) { _model.append(playlists.get(i)); }
+                        }
                         _model.append({key: wpmodel.contentrating});
                         return true;
                     }


### PR DESCRIPTION
Fixes #128

Combined with the ability to randomly cycle through the currently filtered wallpaper list, this should give the ability to cycle through wallpapers like in the Windows app.

This also means you can cycle through the union of two or more playlists or some other combination of playlists and other filters, which is a pretty cool enhancement on the Windows app's capabilities.

Needed to shore up some of the async code as part of the solution to a race condition when configuring multiple displays to shuffle the filter simultaneously.