### PR TITLE
Fix for #415 prevent crash when switching to TTY and back

### DIFF
--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.12
+import com.github.catsout.wallpaperEngineKde 1.2
 import QtQuick.Window 2.2
 import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.plasmoid
@@ -49,6 +50,20 @@ Rectangle {
 
     // auto pause
     property bool   ok: !windowModel.reqPause && !powerSource.reqPause
+
+    // detect TTY switch and pause wallpaper(s)
+    TTYSwitchMonitor {
+        id: ttyMonitor
+        onTtySwitch: {
+            if (sleep) {
+                console.log("Preparing for sleep (possibly a VT switch)");
+                this.pause();
+            } else {
+                console.log("Waking up (VT switch back)");
+                this.play();
+            }
+        }
+    }
 
     property string nowBackend: ""
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Quick Qml)
+find_package(Qt6 REQUIRED COMPONENTS Quick Qml Core DBus)
 
 add_subdirectory(backend_mpv)
 
@@ -13,6 +13,7 @@ add_library(${PROJECT_NAME}
 	SHARED
 	plugin.cpp
 	MouseGrabber.cpp
+	TTYSwitchMonitor.cpp
     PluginInfo.cpp
 	qmldir
 )
@@ -23,6 +24,8 @@ target_link_libraries(${PROJECT_NAME}
 	Qt::Qml 
 	mpvbackend
 	wescene-renderer-qml
+	Qt::Core
+	Qt::DBus
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
 set_target_properties(${PROJECT_NAME}

--- a/src/TTYSwitchMonitor.cpp
+++ b/src/TTYSwitchMonitor.cpp
@@ -1,0 +1,33 @@
+#include "TTYSwitchMonitor.hpp"
+#include <QDebug>
+
+using namespace wekde;
+
+TTYSwitchMonitor::TTYSwitchMonitor(QQuickItem *parent)
+    : QQuickItem(parent), m_sleeping(false) {
+    QDBusConnection systemBus = QDBusConnection::systemBus();
+    if (!systemBus.isConnected()) {
+        qFatal("Cannot connect to the D-Bus system bus");
+        return;
+    }
+
+    bool connected = systemBus.connect(
+        "org.freedesktop.login1",
+        "/org/freedesktop/login1",
+        "org.freedesktop.login1.Manager",
+        "PrepareForSleep",
+        this,
+        SLOT(handlePrepareForSleep(bool))
+    );
+
+    if (!connected) {
+        qFatal("Failed to connect to PrepareForSleep signal");
+    }
+}
+
+void TTYSwitchMonitor::handlePrepareForSleep(bool sleep) {
+    if (m_sleeping != sleep) {
+        m_sleeping = sleep;
+        emit ttySwitch(sleep);
+    }
+}

--- a/src/TTYSwitchMonitor.hpp
+++ b/src/TTYSwitchMonitor.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <QQuickItem>
+#include <QDBusConnection>
+
+namespace wekde {
+
+class TTYSwitchMonitor : public QQuickItem {
+    Q_OBJECT
+    Q_PROPERTY(bool sleeping READ isSleeping NOTIFY ttySwitch)
+
+public:
+    TTYSwitchMonitor(QQuickItem *parent = nullptr);
+
+    bool isSleeping() const { return m_sleeping; }
+
+signals:
+    void ttySwitch(bool sleep);
+
+public slots:
+    void handlePrepareForSleep(bool sleep);
+
+private:
+    bool m_sleeping;
+};
+
+}

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -4,6 +4,7 @@
 #include "MpvBackend.hpp"
 #include "SceneBackend.hpp"
 #include "MouseGrabber.hpp"
+#include "TTYSwitchMonitor.hpp"
 #include "PluginInfo.hpp"
 
 constexpr std::array<uint, 2> WPVer { 1, 2 };
@@ -20,6 +21,7 @@ public:
         qmlRegisterType<scenebackend::SceneObject>(uri, WPVer[0], WPVer[1], "SceneViewer");
         std::setlocale(LC_NUMERIC, "C");
         qmlRegisterType<mpv::MpvObject>(uri, WPVer[0], WPVer[1], "Mpv");
+        qmlRegisterType<wekde::TTYSwitchMonitor>(uri, WPVer[0], WPVer[1], "TTYSwitchMonitor");
     }
 };
 


### PR DESCRIPTION
Fix for #415

Detect when the user is switching TTY and pause wallpapers. Detect when the user returns and unpause.