### PR TITLE
Remove qt6 branch selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Every time you receive update in discover, you should run these commands to upda
 #### Build and Install
 ```sh
 # Download source
-git clone --branch=qt6 https://github.com/catsout/wallpaper-engine-kde-plugin.git
+git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git
 cd wallpaper-engine-kde-plugin
 
 # Download submodule


### PR DESCRIPTION
Merged edit of `git clone` instruction from qt6 will no longer work, since that branch got deleted after. This PR removes selection of qt6 branch in the clone instructions.

Also I think that `support kde6` maybe should be removed from [Todo section](https://github.com/catsout/wallpaper-engine-kde-plugin?tab=readme-ov-file#todo), but that's out of the scope of this PR that just fixes a non working `git clone` command (I can amend it to this one if you want to)