### PR TITLE
Updated Fedora Section of Read Me 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Fedora:
 ```sh
 # Please add "RPM Fusion" repo first
 sudo dnf install vulkan-headers plasma-workspace-devel kf5-plasma-devel gstreamer1-libav \
-lz4-devel mpv-libs-devel python3-websockets qt5-qtbase-private-devel \
+lz4-devel mpv-libs-devel python3-websockets qt5-qtbase-private-devel libplasma-devel \
 qt5-qtx11extras-devel qt5-qtwebchannel-devel qt5-qtwebsockets-devel cmake
 ```
 


### PR DESCRIPTION
Still does not fully compile on Fedora Linux 40, but a step closer. 

Added additional dependency libplasma-devel to the Fedora dependency installation section.