### PR TITLE
Updated Arch section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ qt5-qtx11extras-devel qt5-qtwebchannel-devel qt5-qtwebsockets-devel cmake
 
 Arch:  
 ```sh
-sudo pacman -S extra-cmake-modules plasma-framework5 gst-libav \
+sudo pacman -S extra-cmake-modules plasma-framework5 gst-libav ninja \
 base-devel mpv python-websockets qt5-declarative qt5-websockets qt5-webchannel vulkan-headers cmake
 ```
 


### PR DESCRIPTION
This adds ninja to the pacman command for setup, which is required to perform the build instructions. This addresses issue #434 for Arch (SteamDeck will require some investigation, which I can try later. Someone with more Fedora experience can validate the ninja-build requirement).