### PR TITLE
fix mpv backend build error if Qt version 6.10

### DIFF
--- a/src/backend_mpv/CMakeLists.txt
+++ b/src/backend_mpv/CMakeLists.txt
@@ -1,5 +1,21 @@
 project(mpvbackend)
 
+    # Qt 6.10 has split this into it's own CMake module, it's no longer included with Gui
+    if (Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
+        find_package(Qt6GuiPrivate ${REQUIRED_QT_VERSION} REQUIRED NO_MODULE)
+        get_target_property(Qt6Gui_PRIVATE_INCLUDE_DIRS Qt6::GuiPrivate INTERFACE_INCLUDE_DIRECTORIES)
+
+        # QtGui depends on private headers form QtCore as well
+        find_package(Qt6CorePrivate ${REQUIRED_QT_VERSION} REQUIRED NO_MODULE)
+        get_target_property(Qt6Core_PRIVATE_INCLUDE_DIRS Qt6::CorePrivate INTERFACE_INCLUDE_DIRECTORIES)
+
+        # Currently we depend on the Qt6Gui_PRIVATE_INCLUDE_DIRS variable to selectively include
+        # the needed headers, but it will fail to compile in 6.10 since the private headers exist
+        # in separate directories. So we'll just shove them into the variable we expect for now.
+        list(APPEND Qt6Gui_PRIVATE_INCLUDE_DIRS ${Qt6Core_PRIVATE_INCLUDE_DIRS})
+    endif()
+
+
 find_package(Qt${QT_MAJOR_VERSION} COMPONENTS Gui Quick REQUIRED)
 include_directories(${Qt${QT_MAJOR_VERSION}Gui_PRIVATE_INCLUDE_DIRS})
 


### PR DESCRIPTION
reference here. [Manually define Qt6Gui_PRIVATE_INCLUDE_DIRS CMake variable ](https://invent.kde.org/graphics/krita/-/commit/0d53333f6b4c97e7e295d080c1bb693670336f2a)