### PR TITLE
fixed missing package in readme for debian 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Debian:
 sudo apt install build-essential libvulkan-dev plasma-workspace-dev gstreamer1.0-libav \
 liblz4-dev libmpv-dev python3-websockets qtbase5-private-dev \
 libqt5x11extras5-dev \
-qml-module-qtwebchannel qml-module-qtwebsockets cmake
+qml-module-qtwebchannel qml-module-qtwebsockets cmake ninja-build
 ```  
 
 Fedora:  


### PR DESCRIPTION
I tried installing this on my computer and I noticed that there was a package missing for debian 13, see the error below:

user@hostname:~/git/wallpaper-engine-kde-plugin$ cmake -B build -S . -GNinja -DUSE_PLASMAPKG=ON
CMake Error: CMake was unable to find a build program corresponding to "Ninja".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
