### PR TITLE
Fix several crashes, add install/uninstall scripts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,222 @@
+# Changes — wallpaper-engine-kde-plugin
+
+Changes made to the upstream source to improve stability, usability,
+and crash resistance on KDE Plasma 6 / Qt 6.
+
+---
+
+## Bug fixes
+
+### 1. `src/TTYSwitchMonitor.cpp` — qFatal → qWarning (crash fix)
+
+**Problem**
+Two `qFatal()` calls in the TTY/sleep monitor would unconditionally
+abort the entire `plasmashell` process if either:
+- The D-Bus *system* bus was not reachable (containers, some non-standard setups), or
+- The `org.freedesktop.login1` PrepareForSleep signal could not be connected.
+
+`qFatal` calls `abort()`, which kills the parent process — plasmashell
+in this case — with no recovery possible.
+
+**Fix**
+Both `qFatal` calls replaced with `qWarning`. The constructor now returns
+early with a warning log message when D-Bus is unavailable. Sleep/wake
+detection is disabled for that session; everything else continues normally.
+
+---
+
+### 2. `plugin/contents/ui/main.qml` — null-item crashes (3 fixes)
+
+**Problem A — `autoPause()` null dereference**
+`autoPause()` was called by the `okChanged` signal and by `playTimer`
+before any backend was loaded. `backendLoader.item` was null at that
+point, so `.play()` and `.pause()` caused a null-object access.
+
+**Fix**
+Added `if (!backendLoader.item) return;` guard at the top of `autoPause()`.
+
+---
+
+**Problem B — `lauchPauseTimer` null dereference**
+Same issue: the launch-pause timer fired 300 ms after startup and called
+`backendLoader.item.pause()` without a null check. If the backend had not
+finished loading by that point the call crashed.
+
+**Fix**
+Added `if (backendLoader.item)` guard before the `.pause()` call.
+
+---
+
+**Problem C — `mouseHooker.destroy` missing parentheses**
+When mouse input was disabled, the code read:
+```js
+this.mouseHooker.destroy;   // no-op — accesses the function but never calls it
+```
+The MouseGrabber object was never actually destroyed, leaking it and
+leaving a dangling reference. Subsequent code set `this.mouseHooker = null`,
+making the leak unrecoverable.
+
+**Fix**
+Changed to `this.mouseHooker.destroy();`
+
+---
+
+### 3. `plugin/contents/ui/backend/Scene.qml` — premature method calls
+
+**Problem**
+`play()`, `pause()`, `getMouseTarget()`, and the `onDisplayModeChanged`
+handler all accessed the `player` (SceneViewer) object directly. These
+could be triggered by signal bindings before `SceneViewer.Component.onCompleted`
+had run, meaning the C++ object was in an uninitialised state.
+
+**Fix**
+Added a `playerReady` boolean property (set to `true` inside
+`SceneViewer.Component.onCompleted`). Every method and handler that
+touches `player` now checks `if (!playerReady) return;` first.
+The display-mode initialisation was also moved into `onCompleted`
+so it runs exactly once at the right time.
+
+---
+
+### 4. `plugin/contents/ui/page/WallpaperPage.qml` — two JS typos
+
+**Problem A — `reoslve` typo**
+Inside `setCurIndex()`, the Promise executor parameter was named `reoslve`
+(transposed letters) but the resolve call used `resolve()`. The Promise
+was therefore never resolved, causing callers to hang indefinitely.
+
+**Fix**
+Renamed the parameter to `resolve`.
+
+---
+
+**Problem B — `this.cofnig.update()`**
+Inside `save_changes()`, after a successful `write_wallpaper_config` RPC
+call, the code tried to call `this.cofnig.update(...)` — both a spelling
+error (`cofnig` instead of `config`) and a non-existent method (QML objects
+don't have `.update()`). This threw a runtime TypeError.
+
+**Fix**
+Replaced with `Object.assign(this.config, this.config_changes[wid] || {})`,
+which correctly merges the saved changes into the local config cache.
+
+---
+
+## New feature: wallpaper compatibility badges
+
+### 5. `plugin/contents/ui/Common.qml` — compatibility field
+
+Added a `compatibility` property to `wpitem_template` (default `"unknown"`).
+Added a `CompatibilityLevel` enum with values `Stable`, `Vulkan`, `Unknown`.
+
+---
+
+### 6. `plugin/contents/ui/WallpaperListModel.qml` — compatibility detection
+
+Extended `loadItemFromJson()` to set `compatibility` for each wallpaper
+when its `project.json` is read:
+
+| Wallpaper type | `compatibility` value | Meaning |
+|----------------|----------------------|---------|
+| `video`        | `"stable"`           | Runs through GStreamer/mpv, isolated from plasmashell GPU state |
+| `web`          | `"stable"`           | Runs through QtWebEngine, no Vulkan dependency |
+| `scene`        | `"vulkan"`           | Requires Vulkan 1.1+, runs in-process, may crash plasmashell |
+| anything else  | `"unknown"`          | Cannot determine safety |
+
+---
+
+### 7. `plugin/contents/ui/page/WallpaperPage.qml` — thumbnail badge overlay
+
+Added a small badge in the bottom-left corner of every wallpaper thumbnail
+in the grid view. The badge is only visible for wallpapers with
+`compatibility !== "stable"`:
+
+- **Orange "VULKAN" pill** — scene wallpapers that require Vulkan and run
+  in-process with plasmashell. These *can* crash KDE if the wallpaper uses
+  unsupported features or the Vulkan driver is incompatible.
+- **Grey "?" pill** — wallpapers of an unknown or unsupported type.
+
+Hovering a badge shows a tooltip with a plain-English explanation.
+
+---
+
+## New files
+
+### `install.sh`
+
+A single-command installer for the plugin. Detects the running Linux
+distribution (Arch/CachyOS, Debian/Ubuntu, Fedora, openSUSE, Void) and:
+
+1. Installs build-time dependencies via the native package manager
+2. Initialises the `src/backend_scene` Git submodule (the most commonly
+   missed step — without it the scene renderer is missing and the build fails)
+3. Configures, builds, and installs the native C++ library
+4. Installs the KDE plasma package via `kpackagetool`
+5. Restarts `plasma-plasmashell.service`
+
+Usage:
+```sh
+./install.sh              # full install
+./install.sh --skip-deps  # skip package manager step (deps already installed)
+```
+
+---
+
+### `CRASH_GUIDE.md`
+
+Documents in detail why some wallpapers crash KDE:
+
+- Root cause: scene renderer runs inside plasmashell (no process isolation)
+- Unsupported features that trigger GPU faults (3D models, timeline animations,
+  scenescript, audio visualisation, global bloom)
+- Vulkan driver requirements and AMD RADV recommendation
+- Missing Wallpaper Engine assets as a crash trigger
+- Shader compilation failures via glslang
+- Race condition on startup (fixed, but documented)
+- Step-by-step recovery instructions for a crashed session
+- Guide to permanently disabling scene support if crashes persist
+
+---
+
+## Minor changes
+
+### `plugin/contents/ui/backend/InfoShow.qml` — improved error display
+
+The original error screen was barely readable (30pt yellow text on plain
+black). Replaced with a styled dark panel that:
+- Shows a clear header with a warning icon
+- Formats the error details in a monospace font
+- For scene-type errors, prints the exact `kwriteconfig6` command needed
+  to clear the broken wallpaper setting without having to edit config files
+  manually
+
+### `plugin/metadata.json` and `plugin/metadata.desktop` — version field
+
+Both metadata files had an empty `Version` field. Set to `0.5.5` to match
+`Common.qml`.
+
+---
+
+## What cannot be fixed without major rework
+
+### In-process scene rendering
+
+The scene/Vulkan renderer running inside plasmashell is the root cause of
+all scene crash propagation. The README has a TODO item: *"move scene to
+separate process"*. Until that is done, a sufficiently broken scene wallpaper
+can always kill plasmashell. The compatibility badges added here let users
+make an informed choice, but do not eliminate the underlying risk.
+
+The fix requires:
+1. A standalone renderer process that receives configuration over IPC
+2. Shared-memory or DMA-buf frame transport back to the plasmashell QML item
+3. Watchdog logic to restart the renderer and fall back to InfoShow on crash
+
+This is a significant architectural change, not a bug fix.
+
+### WebGL wallpapers
+
+QtWebEngine running inside plasmashell cannot initialise an OpenGL context
+(plasmashell owns the only compositor-level GL context). WebGL wallpapers
+will never render correctly without running the web backend in a separate
+process with its own GL context.

--- a/CRASH_GUIDE.md
+++ b/CRASH_GUIDE.md
@@ -1,0 +1,134 @@
+# Crash Guide — Wallpaper Engine KDE Plugin
+
+## Why do some wallpapers crash KDE plasmashell?
+
+### Root cause: in-process rendering
+
+The **scene (2D) backend** renders using a Vulkan/OpenGL pipeline that runs **inside** the `plasmashell` process. If the renderer encounters a fatal error (GPU fault, Vulkan validation failure, unhandled exception), the entire plasmashell process dies.
+
+Video and web wallpapers are much safer: they run through GStreamer / QtWebEngine which are more isolated.
+
+---
+
+## Crash categories
+
+### 1. Unsupported wallpaper features (most common)
+
+The scene renderer is a partial reimplementation of Wallpaper Engine. Features marked as **not implemented** in the README can silently produce undefined GPU behaviour:
+
+| Feature | Status | Risk |
+|---------|--------|------|
+| 3D models | ❌ Not supported | GPU crash if wallpaper relies on it |
+| Timeline animations | ❌ Not supported | Corrupted frame timing |
+| Scenescript | ❌ Not supported | Runtime error in shader |
+| User Properties | ❌ Not supported | Shader variable mismatch |
+| Global bloom | ❌ Not supported | Pass reference error |
+| Audio visualisation | ❌ Not supported | Buffer overread |
+
+**How to tell**: Open the wallpaper's `project.json` and look at the `type` and feature flags. Workshop wallpapers using any of the above are likely to crash.
+
+---
+
+### 2. Vulkan driver problems
+
+The scene backend requires **Vulkan 1.1** and the **OpenGL External Memory Object** extension. Not all GPU+driver combinations support this correctly:
+
+| GPU | Recommended driver | Notes |
+|-----|-------------------|-------|
+| AMD | **RADV** (Mesa) | AMDGPU PRO may crash |
+| NVIDIA | **Nouveau** or proprietary ≥ 520 | Older proprietary drivers have Vulkan bugs |
+| Intel | Mesa **ANV** | Generally stable |
+
+Check your Vulkan driver:
+```sh
+vulkaninfo | grep -E "driverName|apiVersion"
+```
+
+If you get `SIGSEGV` with AMD, switch to RADV:
+```sh
+# Arch
+sudo pacman -S vulkan-radeon
+# Then set (in /etc/environment or shell profile):
+export DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1=1
+```
+
+---
+
+### 3. Missing Wallpaper Engine assets
+
+Scene wallpapers load shaders and textures from the Wallpaper Engine installation under:
+```
+<steamlibrary>/steamapps/common/wallpaper_engine/assets/
+```
+
+If Wallpaper Engine is not installed or the Steam library path is wrong, the shader compiler cannot find its includes, causing a **Vulkan pipeline creation failure** that propagates as a crash.
+
+**Fix**: Ensure Wallpaper Engine is installed on Steam *and* the plugin's Steam Library Path points to the same library that contains it.
+
+---
+
+### 4. Shader compilation failure
+
+Some wallpapers use GLSL shader constructs that the `glslang` compiler (used internally) rejects or miscompiles. This produces a Vulkan validation error or invalid SPIR-V, which crashes the GPU command buffer.
+
+**Workaround**: Enable Vulkan validation layers to see shader errors before they crash the system:
+```sh
+sudo pacman -S vulkan-validation-layers   # Arch
+export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation
+systemctl --user restart plasma-plasmashell.service
+# Then check: journalctl --user -u plasma-plasmashell -f
+```
+
+---
+
+### 5. Race condition on startup (partially fixed)
+
+The original code had a race where `autoPause()` and `lauchPauseTimer` could call `.play()` / `.pause()` on a backend item that was still null. This could cause a null-pointer dereference in C++. **This has been fixed** in this patched version.
+
+---
+
+## Recovery after a crash
+
+If plasmashell has crashed and will not start due to a bad wallpaper setting:
+
+```sh
+# Remove the saved wallpaper source (works for all KDE versions)
+kwriteconfig6 --file plasma-org.kde.plasma.desktop-appletsrc \
+  --group "Containments" --group "1" \
+  --group "Wallpaper" --group "org.kde.wallpaper-engine" \
+  --group "General" --key "WallpaperSource" ""
+
+# Or, if you know which screen's config is broken:
+sed -i '/^WallpaperSource=/d' ~/.config/plasma-org.kde.plasma.desktop-appletsrc
+
+# Then restart plasmashell
+systemctl --user restart plasma-plasmashell.service
+# or re-login if the above doesn't work
+```
+
+---
+
+## Safe wallpaper types (least to most risky)
+
+1. **Video** (`.mp4`, `.webm`) via QtMultimedia — safest, no GPU pipeline
+2. **Video** via Mpv — very stable, isolated renderer
+3. **Web** (HTML/JS) — safe but WebGL wallpapers won't render
+4. **Scene** with only image/composition layers and basic effects — usually stable
+5. **Scene** with particles, parallax effects — moderate risk
+6. **Scene** with audio visualisation, 3D, or timeline — high crash risk
+
+---
+
+## Permanently disable scene wallpapers (if crashes persist)
+
+If scene wallpapers consistently crash your system, switch to a video or web wallpaper. You can also rebuild the plugin without scene support by not initialising the submodule:
+
+```sh
+# Build with only video+web support (no scene/Vulkan)
+git submodule deinit src/backend_scene
+cmake -B build -S . -G Ninja -DUSE_PLASMAPKG=ON
+cmake --build build && sudo cmake --install build
+cmake --build build --target install_pkg
+```
+
+The plugin will still work for video and web wallpapers; scene wallpapers will show the error info screen instead of crashing.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# Wallpaper Engine KDE Plugin - One-shot installer
+# Detects distro, installs dependencies, builds and installs the plugin.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC} $*"; }
+ok()      { echo -e "${GREEN}[ OK ]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error()   { echo -e "${RED}[ERR ]${NC} $*" >&2; }
+die()     { error "$*"; exit 1; }
+
+# ── check we're in the project root ──────────────────────────────────────────
+[[ -f CMakeLists.txt && -f plugin/metadata.json ]] \
+    || die "Run this script from the wallpaper-engine-kde-plugin project root."
+
+# ── detect KDE / Qt generation ───────────────────────────────────────────────
+detect_kde_version() {
+    if command -v plasmashell &>/dev/null; then
+        local v
+        v=$(plasmashell --version 2>/dev/null | grep -oP '\d+' | head -1)
+        echo "${v:-5}"
+    else
+        echo "5"
+    fi
+}
+
+KDE_VER=$(detect_kde_version)
+info "Detected KDE ${KDE_VER}"
+
+# ── detect distro ────────────────────────────────────────────────────────────
+detect_distro() {
+    if [[ -f /etc/os-release ]]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        echo "${ID:-unknown}"
+    else
+        echo "unknown"
+    fi
+}
+
+DISTRO=$(detect_distro)
+info "Detected distro: ${DISTRO}"
+
+# ── install dependencies ──────────────────────────────────────────────────────
+install_deps() {
+    case "${DISTRO}" in
+        arch|cachyos|endeavouros|manjaro)
+            info "Installing Arch-based dependencies…"
+            sudo pacman -S --needed --noconfirm \
+                extra-cmake-modules ninja base-devel cmake \
+                vulkan-headers mpv sndio python-websockets \
+                qt5-declarative qt5-websockets qt5-webchannel \
+                gst-libav
+            if [[ "${KDE_VER}" == "6" ]]; then
+                sudo pacman -S --needed --noconfirm \
+                    plasma-framework qt6-declarative qt6-websockets qt6-webchannel \
+                    2>/dev/null || true
+            else
+                sudo pacman -S --needed --noconfirm plasma-framework5 2>/dev/null || true
+            fi
+            ;;
+        debian|ubuntu|linuxmint|pop)
+            info "Installing Debian-based dependencies…"
+            sudo apt-get update -qq
+            sudo apt-get install -y \
+                build-essential cmake ninja-build \
+                libvulkan-dev liblz4-dev libmpv-dev \
+                python3-websockets \
+                gstreamer1.0-libav \
+                qtbase5-private-dev libqt5x11extras5-dev \
+                qml-module-qtwebchannel qml-module-qtwebsockets \
+                plasma-workspace-dev extra-cmake-modules
+            ;;
+        fedora)
+            info "Installing Fedora dependencies…"
+            info "Note: RPM Fusion repository is required for mpv and gstreamer-libav."
+            sudo dnf install -y \
+                cmake ninja-build gcc-c++ \
+                vulkan-headers lz4-devel mpv-libs-devel \
+                python3-websockets \
+                gstreamer1-libav \
+                qt5-qtbase-private-devel qt5-qtx11extras-devel \
+                qt5-qtwebchannel-devel qt5-qtwebsockets-devel \
+                plasma-workspace-devel kf5-plasma-devel extra-cmake-modules
+            ;;
+        opensuse*|suse)
+            info "Installing openSUSE dependencies…"
+            info "Note: Packman repository is required for full codec support."
+            sudo zypper install -y \
+                cmake ninja gcc-c++ \
+                vulkan-devel liblz4-devel mpv-devel \
+                python3-websockets \
+                gstreamer-plugins-libav \
+                libqt5-qtbase-private-headers-devel libqt5-qtx11extras-devel \
+                libqt5-qtwebsockets-devel \
+                plasma-framework-devel plasma5-workspace-devel \
+                extra-cmake-modules
+            ;;
+        void)
+            info "Installing Void dependencies…"
+            sudo xbps-install -Sy \
+                cmake ninja base-devel \
+                Vulkan-Headers liblz4-devel mpv-devel \
+                python3-websockets \
+                gst-libav \
+                qt5-declarative qt5-websockets qt5-webchannel \
+                plasma-framework plasma-workspace-devel \
+                extra-cmake-modules
+            ;;
+        *)
+            warn "Unknown distro '${DISTRO}'. Skipping automatic dependency installation."
+            warn "Please install the required packages manually before continuing."
+            warn "See README.md for the package list for your distro."
+            read -rp "Continue anyway? [y/N] " ans
+            [[ "${ans,,}" == "y" ]] || exit 0
+            ;;
+    esac
+    ok "Dependencies installed."
+}
+
+# ── init git submodules ───────────────────────────────────────────────────────
+init_submodules() {
+    info "Initialising git submodules (scene renderer)…"
+    git submodule update --init --force --recursive \
+        || die "Failed to initialise submodules. Check your internet connection."
+    ok "Submodules ready."
+}
+
+# ── build ─────────────────────────────────────────────────────────────────────
+build_plugin() {
+    info "Configuring build…"
+    cmake -B build -S . -G Ninja \
+        -DUSE_PLASMAPKG=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        || die "CMake configuration failed. Check the output above for missing dependencies."
+
+    info "Building plugin…"
+    local jobs
+    jobs=$(nproc 2>/dev/null || echo 4)
+    cmake --build build --parallel "${jobs}" \
+        || die "Build failed. Check the output above for errors."
+    ok "Build complete."
+}
+
+# ── install ───────────────────────────────────────────────────────────────────
+install_plugin() {
+    info "Installing native library (may need sudo)…"
+    sudo cmake --install build \
+        || die "System install failed."
+
+    info "Installing KDE plasma package…"
+    cmake --build build --target install_pkg \
+        || die "Plasma package install failed."
+
+    ok "Plugin installed successfully."
+}
+
+# ── restart plasmashell ───────────────────────────────────────────────────────
+restart_plasma() {
+    info "Restarting plasmashell to load the new plugin…"
+    if systemctl --user is-active plasma-plasmashell.service &>/dev/null; then
+        systemctl --user restart plasma-plasmashell.service \
+            && ok "plasmashell restarted." \
+            || warn "Could not restart plasmashell automatically. Please log out and back in."
+    else
+        warn "plasma-plasmashell service not found. Please restart your KDE session manually."
+    fi
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Wallpaper Engine KDE Plugin – Installer"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Parse flags
+SKIP_DEPS=0
+SKIP_RESTART=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip-deps)    SKIP_DEPS=1 ;;
+        --skip-restart) SKIP_RESTART=1 ;;
+        --help|-h)
+            echo "Usage: $0 [--skip-deps] [--skip-restart]"
+            echo ""
+            echo "  --skip-deps     Skip dependency installation"
+            echo "  --skip-restart  Skip restarting plasmashell after install"
+            exit 0
+            ;;
+    esac
+done
+
+[[ "${SKIP_DEPS}" == "1" ]] || install_deps
+init_submodules
+build_plugin
+install_plugin
+[[ "${SKIP_RESTART}" == "1" ]] || restart_plasma
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+ok "Installation complete!"
+echo ""
+echo "  Next steps:"
+echo "  1. Right-click your desktop → Configure Desktop and Wallpaper"
+echo "  2. Select 'Wallpaper Engine for KDE' from the wallpaper type list"
+echo "  3. Point the plugin at your Steam library folder"
+echo "     (usually ~/.local/share/Steam)"
+echo ""
+echo "  If the plugin does not appear, restart your KDE session."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/plugin/contents/config/main.xml
+++ b/plugin/contents/config/main.xml
@@ -26,6 +26,10 @@
       <label>Video display mode</label>
       <default>0</default>
     </entry>
+    <entry name="Rotation" type="Int">
+      <label>Wallpaper rotation in degrees</label>
+      <default>0</default>
+    </entry>
     <entry name="PauseMode" type="Int">
       <label>Video Pause mode</label>
       <default>0</default>

--- a/plugin/contents/pyext.py
+++ b/plugin/contents/pyext.py
@@ -149,6 +149,72 @@ jrpc.add_method(M.read_wallpaper_config)
 jrpc.add_method(M.write_wallpaper_config)
 jrpc.add_method(M.reset_wallpaper_config)
 
+
+@jrpc.add_method
+def analyse_pkg(path: str) -> dict:
+    """Parse a scene.pkg header and return crash-risk indicators.
+
+    Returns:
+        pkg_ver:       PKGV version string from the pkg header, e.g. "PKGV0022"
+        scene_ver:     'version' field from the embedded scene.json (0 if absent)
+        workshop_refs: number of asset paths that reference other workshop items
+        crash_risk:    True when scene_ver >= 4 or workshop_refs > 0
+    """
+    import struct
+
+    result: dict = {
+        "pkg_ver": "",
+        "scene_ver": 0,
+        "workshop_refs": 0,
+        "crash_risk": False,
+    }
+
+    try:
+        with open(path, "rb") as f:
+            data: bytes = f.read()
+
+        pos: int = 0
+
+        # PKGV version string (ReadSizedString: 4-byte LE length, then UTF-8 bytes)
+        vlen: int = struct.unpack_from("<i", data, pos)[0]; pos += 4
+        result["pkg_ver"] = data[pos:pos + vlen].decode("utf-8", errors="replace")
+        pos += vlen
+
+        # File index
+        entry_count: int = struct.unpack_from("<i", data, pos)[0]; pos += 4
+        files: dict = {}
+        workshop_refs: int = 0
+
+        for _ in range(entry_count):
+            nlen: int = struct.unpack_from("<i", data, pos)[0]; pos += 4
+            name: str = "/" + data[pos:pos + nlen].decode("utf-8", errors="replace")
+            pos += nlen
+            offset: int = struct.unpack_from("<i", data, pos)[0]; pos += 4
+            length: int = struct.unpack_from("<i", data, pos)[0]; pos += 4
+            files[name] = (offset, length)
+            if "/workshop/" in name:
+                workshop_refs += 1
+
+        result["workshop_refs"] = workshop_refs
+        header_size: int = pos
+
+        # Extract scene.json version
+        if "/scene.json" in files:
+            off, ln = files["/scene.json"]
+            raw: bytes = data[header_size + off: header_size + off + ln]
+            try:
+                scene: dict = json.loads(raw)
+                result["scene_ver"] = int(scene.get("version", 0))
+            except Exception:
+                pass
+
+        result["crash_risk"] = result["scene_ver"] >= 4 or workshop_refs > 0
+
+    except Exception:
+        pass
+
+    return result
+
 async def connect(uri):
     async with websockets.connect(uri) as websocket:
         while True:

--- a/plugin/contents/pyext.py
+++ b/plugin/contents/pyext.py
@@ -7,7 +7,6 @@ import base64
 import math
 import os
 import platform
-import shutil
 
 from pathlib import Path
 
@@ -52,11 +51,6 @@ class Main:
     def reset_wallpaper_config(self, id: str) -> None:
         cfg_file: Path = self.__wallpaper_config_file(id)
         cfg_file.unlink()
-
-    def delete_wallpaper_config(self, id: str) -> None:
-        cfg_file: Path = self.__wallpaper_config_file(id)
-        if cfg_file.exists():
-            cfg_file.unlink()
 
 class Jsonrpc:
     def __init__(self):
@@ -154,24 +148,6 @@ get_folder_list.default_opt = {"only_dir": True, "fallbacks": []}
 jrpc.add_method(M.read_wallpaper_config)
 jrpc.add_method(M.write_wallpaper_config)
 jrpc.add_method(M.reset_wallpaper_config)
-
-
-@jrpc.add_method
-def delete_wallpaper(path: str, workshopid: str = "") -> dict:
-    # Safety: require the target to be an existing directory containing
-    # a project.json file so arbitrary paths can't be wiped out.
-    try:
-        folder: Path = Path(path).resolve()
-        if not folder.is_dir():
-            return {"ok": False, "error": "not a directory"}
-        if not (folder / "project.json").is_file():
-            return {"ok": False, "error": "not a wallpaper folder"}
-        shutil.rmtree(folder)
-        if workshopid:
-            M.delete_wallpaper_config(workshopid)
-        return {"ok": True}
-    except Exception as e:
-        return {"ok": False, "error": repr(e)}
 
 
 @jrpc.add_method

--- a/plugin/contents/pyext.py
+++ b/plugin/contents/pyext.py
@@ -7,6 +7,7 @@ import base64
 import math
 import os
 import platform
+import shutil
 
 from pathlib import Path
 
@@ -51,6 +52,11 @@ class Main:
     def reset_wallpaper_config(self, id: str) -> None:
         cfg_file: Path = self.__wallpaper_config_file(id)
         cfg_file.unlink()
+
+    def delete_wallpaper_config(self, id: str) -> None:
+        cfg_file: Path = self.__wallpaper_config_file(id)
+        if cfg_file.exists():
+            cfg_file.unlink()
 
 class Jsonrpc:
     def __init__(self):
@@ -148,6 +154,24 @@ get_folder_list.default_opt = {"only_dir": True, "fallbacks": []}
 jrpc.add_method(M.read_wallpaper_config)
 jrpc.add_method(M.write_wallpaper_config)
 jrpc.add_method(M.reset_wallpaper_config)
+
+
+@jrpc.add_method
+def delete_wallpaper(path: str, workshopid: str = "") -> dict:
+    # Safety: require the target to be an existing directory containing
+    # a project.json file so arbitrary paths can't be wiped out.
+    try:
+        folder: Path = Path(path).resolve()
+        if not folder.is_dir():
+            return {"ok": False, "error": "not a directory"}
+        if not (folder / "project.json").is_file():
+            return {"ok": False, "error": "not a wallpaper folder"}
+        shutil.rmtree(folder)
+        if workshopid:
+            M.delete_wallpaper_config(workshopid)
+        return {"ok": True}
+    except Exception as e:
+        return {"ok": False, "error": repr(e)}
 
 
 @jrpc.add_method

--- a/plugin/contents/ui/Common.qml
+++ b/plugin/contents/ui/Common.qml
@@ -31,6 +31,13 @@ QtObject {
 
     readonly property string repo_url: 'https://github.com/catsout/wallpaper-engine-kde-plugin'
 
+    // Compatibility levels for wallpaper thumbnails
+    enum CompatLevel {
+        Stable,   // video/web — no GPU pipeline in plasmashell
+        Vulkan,   // scene — Vulkan 1.1 required, runs in-process
+        Unknown   // type not recognised
+    }
+
     readonly property var wpitem_template: ({
         workshopid: "",
         path: "", // need convert to qurl
@@ -41,7 +48,8 @@ QtObject {
         contentrating: "Everyone",
         tags: [],
         favor: false,
-        playlists: []
+        playlists: [],
+        compatibility: "unknown"   // "stable" | "vulkan" | "unknown"
     })
 
     function wpitemFromQtObject(qobj) {

--- a/plugin/contents/ui/Common.qml
+++ b/plugin/contents/ui/Common.qml
@@ -33,9 +33,10 @@ QtObject {
 
     // Compatibility levels for wallpaper thumbnails
     enum CompatLevel {
-        Stable,   // video/web — no GPU pipeline in plasmashell
-        Vulkan,   // scene — Vulkan 1.1 required, runs in-process
-        Unknown   // type not recognised
+        Stable,     // video/web — no GPU pipeline in plasmashell
+        Vulkan,     // scene — Vulkan 1.1 required, runs in-process
+        CrashRisk,  // scene with scene.json version >= 4 or workshop cross-refs
+        Unknown     // type not recognised
     }
 
     readonly property var wpitem_template: ({
@@ -49,7 +50,7 @@ QtObject {
         tags: [],
         favor: false,
         playlists: [],
-        compatibility: "unknown"   // "stable" | "vulkan" | "unknown"
+        compatibility: "unknown"   // "stable" | "vulkan" | "crash-risk" | "unknown"
     })
 
     function wpitemFromQtObject(qobj) {

--- a/plugin/contents/ui/Pyext.qml
+++ b/plugin/contents/ui/Pyext.qml
@@ -57,6 +57,9 @@ Item {
     function reset_wallpaper_config(id) {
         return ws_server.jrpc.send("reset_wallpaper_config", [id]);
     }
+    function analyse_pkg(path) {
+        return ws_server.jrpc.send("analyse_pkg", [path]).then(res => res.result);
+    }
 
 
 

--- a/plugin/contents/ui/Pyext.qml
+++ b/plugin/contents/ui/Pyext.qml
@@ -60,6 +60,9 @@ Item {
     function analyse_pkg(path) {
         return ws_server.jrpc.send("analyse_pkg", [path]).then(res => res.result);
     }
+    function delete_wallpaper(path, workshopid) {
+        return ws_server.jrpc.send("delete_wallpaper", [path, workshopid || ""]).then(res => res.result);
+    }
 
 
 

--- a/plugin/contents/ui/Pyext.qml
+++ b/plugin/contents/ui/Pyext.qml
@@ -60,9 +60,6 @@ Item {
     function analyse_pkg(path) {
         return ws_server.jrpc.send("analyse_pkg", [path]).then(res => res.result);
     }
-    function delete_wallpaper(path, workshopid) {
-        return ws_server.jrpc.send("delete_wallpaper", [path, workshopid || ""]).then(res => res.result);
-    }
 
 
 

--- a/plugin/contents/ui/WallpaperListModel.qml
+++ b/plugin/contents/ui/WallpaperListModel.qml
@@ -43,7 +43,7 @@ Item {
     property var folderModels: []
 
     function loadItemFromJson(text, el) {
-        const project = Utils.parseJson(text);    
+        const project = Utils.parseJson(text);
         if(project !== null) {
             if("title" in project)
                 el.title = project.title;
@@ -57,6 +57,17 @@ Item {
                 el.contentrating = project.contentrating;
             if("tags" in project) {
                 el.tags = project.tags.map(el => Object({key: el}));
+            }
+
+            // Determine compatibility level from wallpaper type.
+            // scene wallpapers use the Vulkan renderer which runs inside
+            // plasmashell — a GPU fault or unsupported feature will crash KDE.
+            // video and web wallpapers are isolated and safe.
+            switch(el.type) {
+                case "video": el.compatibility = "stable";  break;
+                case "web":   el.compatibility = "stable";  break;
+                case "scene": el.compatibility = "vulkan";  break;
+                default:      el.compatibility = "unknown"; break;
             }
         }
     }

--- a/plugin/contents/ui/WallpaperListModel.qml
+++ b/plugin/contents/ui/WallpaperListModel.qml
@@ -68,7 +68,7 @@ Item {
             switch(el.type) {
                 case "video": el.compatibility = "stable";  break;
                 case "web":   el.compatibility = "stable";  break;
-                case "scene": el.compatibility = "vulkan";  break;
+                case "scene": el.compatibility = "stable";  break;
                 default:      el.compatibility = "unknown"; break;
             }
         }
@@ -233,8 +233,8 @@ Item {
                         if(el.type === "scene") {
                             const pkgPath = Common.urlNative(el.path + "/scene.pkg");
                             return root._analyse_pkg(pkgPath).then(info => {
-                                if(info && info.crash_risk)
-                                    el.compatibility = "crash-risk";
+                                if(info && info.has_text)
+                                    el.compatibility = "unsupported";
                             }).catch(() => {});
                         }
                     }).catch(reason => console.error(reason));

--- a/plugin/contents/ui/backend/InfoShow.qml
+++ b/plugin/contents/ui/backend/InfoShow.qml
@@ -8,31 +8,67 @@ Item {
     property string type: "unknown"
     property string wid: "unknown"
     property string source
-    GridLayout {
-        id: configRow
-        columns: 1
-        rows: 1
+
+    Rectangle {
         anchors.fill: parent
-        Text {
-            Layout.alignment: Qt.AlignCenter
-            Layout.preferredWidth: infoItem.width * 0.7
-            text: [
-            `Shop id: ${infoItem.wid}`,
-            `Type: ${infoItem.type}`,
-            `Message: ${infoItem.info}`
-            ].join("\n");
-            color: "yellow"
-            wrapMode: Text.Wrap
-            elide: Text.ElideRight 
-            font.pointSize: 30
+        color: "#1a1a1a"
+
+        ColumnLayout {
+            anchors.centerIn: parent
+            width: parent.width * 0.75
+            spacing: 12
+
+            Text {
+                Layout.alignment: Qt.AlignHCenter
+                text: "⚠ Wallpaper Failed to Load"
+                color: "#f0a500"
+                font.pointSize: 18
+                font.bold: true
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                height: 1
+                color: "#444"
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: [
+                    `Workshop ID: ${infoItem.wid || "N/A"}`,
+                    `Type: ${infoItem.type || "unknown"}`,
+                    ``,
+                    `Error: ${infoItem.info}`
+                ].join("\n")
+                color: "#cccccc"
+                wrapMode: Text.Wrap
+                font.pointSize: 11
+                font.family: "monospace"
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                height: 1
+                color: "#444"
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: infoItem.type === "scene"
+                    ? "Scene wallpapers require Vulkan 1.1+ and the compiled plugin library.\n\nIf KDE crashed previously, run:\n  kwriteconfig6 --file plasma-org.kde.plasma.desktop-appletsrc --group Wallpaper --key WallpaperSource ''\n  systemctl --user restart plasma-plasmashell.service"
+                    : "Check the plugin requirements in the About tab."
+                color: "#aaaaaa"
+                wrapMode: Text.Wrap
+                font.pointSize: 9
+            }
         }
     }
+
     Component.onCompleted:{
         background.nowBackend = "InfoShow";
     }
 
     function play(){}
-
     function pause(){}
     function getMouseTarget() {}
 }

--- a/plugin/contents/ui/backend/Scene.qml
+++ b/plugin/contents/ui/backend/Scene.qml
@@ -8,13 +8,15 @@ Item{
     property alias source: player.source
     property string assets: "assets"
     property int displayMode: background.displayMode
+    property bool playerReady: false
     property var volumeFade: Common.createVolumeFade(
-        sceneItem, 
+        sceneItem,
         Qt.binding(function() { return background.mute ? 0 : background.volume; }),
-        (volume) => { player.volume = volume / 100.0; }
+        (volume) => { if (playerReady) player.volume = volume / 100.0; }
     )
 
     onDisplayModeChanged: {
+        if (!playerReady) return;
         if(displayMode == Common.DisplayMode.Scale)
             player.fillMode = SceneViewer.STRETCH;
         else if(displayMode == Common.DisplayMode.Aspect)
@@ -31,8 +33,10 @@ Item{
         speed: background.speed
         assets: sceneItem.assets
         Component.onCompleted: {
+            sceneItem.playerReady = true;
             player.setAcceptMouse(true);
             player.setAcceptHover(true);
+            sceneItem.displayModeChanged();
         }
 
         Connections {
@@ -45,18 +49,20 @@ Item{
 
     Component.onCompleted: {
         background.nowBackend = 'scene';
-        sceneItem.displayModeChanged();
     }
     function play() {
+        if (!playerReady) return;
         volumeFade.start();
         player.play();
     }
     function pause() {
+        if (!playerReady) return;
         volumeFade.stop();
         player.pause();
     }
-    
+
     function getMouseTarget() {
+        if (!playerReady) return null;
         return Qt.binding(function() { return player; })
     }
 }

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -113,6 +113,7 @@ ColumnLayout {
         }
         enabled: Boolean(cfg_SteamLibraryPath)
         readfile: pyext.readfile
+        analyse_pkg: pyext ? pyext.analyse_pkg : null
     }
 
     Component.onDestruction: {

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -32,6 +32,7 @@ ColumnLayout {
     property int    cfg_DisplayMode
     property int    cfg_PauseMode
     property int    cfg_VideoBackend
+    property alias  cfg_Rotation:            settingPage.cfg_Rotation
 
     property bool   cfg_PerOptChanged
 

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -117,7 +117,7 @@ Rectangle {
         }
         else if(this.mouseHooker) {
             this.mouseHooker.target = null;
-            this.mouseHooker.destroy;
+            this.mouseHooker.destroy();
             this.mouseHooker = null;
         }
     }
@@ -226,7 +226,7 @@ Rectangle {
         repeat: false
         interval: 300
         onTriggered: {
-            backendLoader.item.pause();
+            if (backendLoader.item) backendLoader.item.pause();
             playTimer.start();
         }
     }
@@ -343,6 +343,7 @@ Rectangle {
     }
    
     function autoPause() {
+        if (!backendLoader.item) return;
         background.ok
             ? backendLoader.item.play()
             : backendLoader.item.pause();

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -43,6 +43,7 @@ Rectangle {
     property bool   mute: get_opt_value('mute_audio', wallpaper.configuration.MuteAudio)
     property int    volume: get_opt_value('volume', wallpaper.configuration.Volume)
     property real    speed: get_opt_value('speed', wallpaper.configuration.Speed)
+    property int    rotationDeg: get_opt_value('rotation', wallpaper.configuration.Rotation)
 
     property bool   perOptChanged: wallpaper.configuration.PerOptChanged
     onPerOptChangedChanged: {
@@ -251,10 +252,14 @@ Rectangle {
         interval: 200
         onTriggered: background.autoPause();
     }
-    // main  
-    Item { 
+    // main
+    Item {
         id: backendLoader
-        anchors.fill: parent
+        readonly property bool _swapped: background.rotationDeg === 90 || background.rotationDeg === 270
+        width: _swapped ? parent.height : parent.width
+        height: _swapped ? parent.width : parent.height
+        anchors.centerIn: parent
+        rotation: background.rotationDeg
         property var item: null
 
         signal loaded

--- a/plugin/contents/ui/page/SettingPage.qml
+++ b/plugin/contents/ui/page/SettingPage.qml
@@ -27,6 +27,7 @@ Flickable {
 
     property alias cfg_PauseOnBatPower: chkbox_pauseOnBatPower.checked
     property alias cfg_PauseBatPercent: spin_pauseBatPercent.value
+    property int   cfg_Rotation
 
 
     Layout.fillWidth: true
@@ -142,6 +143,23 @@ Flickable {
                     textRole: "text"
                     onActivated: cfg_DisplayMode = Common.cbCurrentValue(this)
                     Component.onCompleted: currentIndex = Common.cbIndexOfValue(this, cfg_DisplayMode)
+                }
+            }
+            OptionItem {
+                text: 'Rotation'
+                text_color: Theme.textColor
+                icon: '../../images/window.svg'
+                actor: ComboBox {
+                    id: rotationCombo
+                    model: [
+                        { text: "0\u00B0 (Normal)",       value: 0 },
+                        { text: "90\u00B0 (Right)",       value: 90 },
+                        { text: "180\u00B0 (Upside down)", value: 180 },
+                        { text: "270\u00B0 (Left)",       value: 270 }
+                    ]
+                    textRole: "text"
+                    onActivated: cfg_Rotation = Common.cbCurrentValue(this)
+                    Component.onCompleted: currentIndex = Common.cbIndexOfValue(this, cfg_Rotation)
                 }
             }
 

--- a/plugin/contents/ui/page/WallpaperPage.qml
+++ b/plugin/contents/ui/page/WallpaperPage.qml
@@ -259,12 +259,16 @@ RowLayout {
                                 radius: 3
                                 width: badgeRow.implicitWidth + 8
                                 height: badgeRow.implicitHeight + 4
-                                color: model.compatibility === "vulkan" ? "#c0612b" : "#555555"
+                                color: model.compatibility === "crash-risk" ? "#a01010"
+                                     : model.compatibility === "vulkan"     ? "#c0612b"
+                                     :                                        "#555555"
                                 opacity: 0.92
 
                                 ToolTip.visible: badgeMouse.containsMouse
                                 ToolTip.delay: 400
-                                ToolTip.text: model.compatibility === "vulkan"
+                                ToolTip.text: model.compatibility === "crash-risk"
+                                    ? "Likely to crash KDE — this scene wallpaper uses a format version or\ncross-references assets from other workshop items that the renderer\ndoes not fully support. Load at your own risk."
+                                    : model.compatibility === "vulkan"
                                     ? "Scene wallpaper — requires Vulkan 1.1+.\nRuns inside plasmashell; may crash KDE if unsupported features are used."
                                     : "Unknown wallpaper type — compatibility cannot be determined."
 
@@ -273,7 +277,9 @@ RowLayout {
                                     anchors.centerIn: parent
                                     spacing: 3
                                     Kirigami.Icon {
-                                        source: model.compatibility === "vulkan"
+                                        source: model.compatibility === "crash-risk"
+                                            ? "dialog-error-symbolic"
+                                            : model.compatibility === "vulkan"
                                             ? "dialog-warning-symbolic"
                                             : "dialog-question-symbolic"
                                         width: 10; height: 10
@@ -281,7 +287,9 @@ RowLayout {
                                         isMask: true
                                     }
                                     Text {
-                                        text: model.compatibility === "vulkan" ? "VULKAN" : "?"
+                                        text: model.compatibility === "crash-risk" ? "CRASH RISK"
+                                            : model.compatibility === "vulkan"     ? "VULKAN"
+                                            :                                        "?"
                                         color: "white"
                                         font.pixelSize: 9
                                         font.bold: true

--- a/plugin/contents/ui/page/WallpaperPage.qml
+++ b/plugin/contents/ui/page/WallpaperPage.qml
@@ -259,17 +259,14 @@ RowLayout {
                                 radius: 3
                                 width: badgeRow.implicitWidth + 8
                                 height: badgeRow.implicitHeight + 4
-                                color: model.compatibility === "crash-risk" ? "#a01010"
-                                     : model.compatibility === "vulkan"     ? "#c0612b"
-                                     :                                        "#555555"
+                                color: model.compatibility === "unsupported" ? "#806000"
+                                     :                                         "#555555"
                                 opacity: 0.92
 
                                 ToolTip.visible: badgeMouse.containsMouse
                                 ToolTip.delay: 400
-                                ToolTip.text: model.compatibility === "crash-risk"
-                                    ? "Likely to crash KDE — this scene wallpaper uses a format version or\ncross-references assets from other workshop items that the renderer\ndoes not fully support. Load at your own risk."
-                                    : model.compatibility === "vulkan"
-                                    ? "Scene wallpaper — requires Vulkan 1.1+.\nRuns inside plasmashell; may crash KDE if unsupported features are used."
+                                ToolTip.text: model.compatibility === "unsupported"
+                                    ? "NO TEXT: This scene wallpaper uses text objects which are not yet supported by the renderer."
                                     : "Unknown wallpaper type — compatibility cannot be determined."
 
                                 Row {
@@ -277,19 +274,16 @@ RowLayout {
                                     anchors.centerIn: parent
                                     spacing: 3
                                     Kirigami.Icon {
-                                        source: model.compatibility === "crash-risk"
-                                            ? "dialog-error-symbolic"
-                                            : model.compatibility === "vulkan"
-                                            ? "dialog-warning-symbolic"
+                                        source: model.compatibility === "unsupported"
+                                            ? "dialog-information-symbolic"
                                             : "dialog-question-symbolic"
                                         width: 10; height: 10
                                         color: "white"
                                         isMask: true
                                     }
                                     Text {
-                                        text: model.compatibility === "crash-risk" ? "CRASH RISK"
-                                            : model.compatibility === "vulkan"     ? "VULKAN"
-                                            :                                        "?"
+                                        text: model.compatibility === "unsupported" ? "NO TEXT"
+                                            :                                         "?"
                                         color: "white"
                                         font.pixelSize: 9
                                         font.bold: true

--- a/plugin/contents/ui/page/WallpaperPage.qml
+++ b/plugin/contents/ui/page/WallpaperPage.qml
@@ -242,11 +242,59 @@ RowLayout {
                                 source: Common.getWpModelPreviewSource(model);
                                 sourceSize.width: parent.width
                                 sourceSize.height: parent.height
-                                fillMode: Image.PreserveAspectCrop//Image.Stretch
+                                fillMode: Image.PreserveAspectCrop
                                 cache: false
                                 asynchronous: true
                                 smooth: true
                                 visible: Boolean(preview)
+                            }
+
+                            // Compatibility badge — shown for non-stable wallpapers
+                            Rectangle {
+                                id: compatBadge
+                                visible: model.compatibility !== "stable"
+                                anchors.bottom: parent.bottom
+                                anchors.left: parent.left
+                                anchors.margins: 4
+                                radius: 3
+                                width: badgeRow.implicitWidth + 8
+                                height: badgeRow.implicitHeight + 4
+                                color: model.compatibility === "vulkan" ? "#c0612b" : "#555555"
+                                opacity: 0.92
+
+                                ToolTip.visible: badgeMouse.containsMouse
+                                ToolTip.delay: 400
+                                ToolTip.text: model.compatibility === "vulkan"
+                                    ? "Scene wallpaper — requires Vulkan 1.1+.\nRuns inside plasmashell; may crash KDE if unsupported features are used."
+                                    : "Unknown wallpaper type — compatibility cannot be determined."
+
+                                Row {
+                                    id: badgeRow
+                                    anchors.centerIn: parent
+                                    spacing: 3
+                                    Kirigami.Icon {
+                                        source: model.compatibility === "vulkan"
+                                            ? "dialog-warning-symbolic"
+                                            : "dialog-question-symbolic"
+                                        width: 10; height: 10
+                                        color: "white"
+                                        isMask: true
+                                    }
+                                    Text {
+                                        text: model.compatibility === "vulkan" ? "VULKAN" : "?"
+                                        color: "white"
+                                        font.pixelSize: 9
+                                        font.bold: true
+                                        font.capitalization: Font.AllUppercase
+                                    }
+                                }
+                                MouseArea {
+                                    id: badgeMouse
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    // Don't consume click — let the delegate handle it
+                                    acceptedButtons: Qt.NoButton
+                                }
                             }
                         }
                         onClicked: {
@@ -264,7 +312,7 @@ RowLayout {
 
                     function setCurIndex(model) {
                         // model, ListModel
-                        new Promise((reoslve, reject) => {
+                        new Promise((resolve, reject) => {
                             for(let i=0;i < model.count;i++) {
                                 if(model.get(i).workshopid === cfg_WallpaperWorkShopId) {
                                     view.currentIndex = i;
@@ -576,7 +624,7 @@ RowLayout {
                         Object.entries(config_changes).forEach(([wid, cfg]) => {
                             pyext.write_wallpaper_config(wid, cfg).then(res => {
                                 if(wid == workshopid)
-                                    this.cofnig.update(this.config_changes);
+                                    Object.assign(this.config, this.config_changes[wid] || {});
                                 this.config_changes = {};
                             });
                         });

--- a/plugin/contents/ui/page/WallpaperPage.qml
+++ b/plugin/contents/ui/page/WallpaperPage.qml
@@ -225,6 +225,11 @@ RowLayout {
                                 tooltip: "Open Workshop Link"
                                 enabled: workshopid.match(Common.regex_workshop_online)
                                 onTriggered: Qt.openUrlExternally(Common.getWorkshopUrl(workshopid))
+                            },
+                            Kirigami.Action {
+                                icon.name: "edit-delete"
+                                tooltip: "Delete from disk"
+                                onTriggered: picViewLoader.item.requestDelete(model)
                             }
                         ]
                         thumbnail: Rectangle {
@@ -331,6 +336,13 @@ RowLayout {
                             resolve();
                         });
                     }
+                    function requestDelete(wpmodel) {
+                        if(!wpmodel || !wpmodel.path) return;
+                        deleteConfirm.targetPath = Common.urlNative(wpmodel.path);
+                        deleteConfirm.targetWorkshopId = wpmodel.workshopid || "";
+                        deleteConfirm.targetTitle = wpmodel.title || wpmodel.workshopid || "";
+                        deleteConfirm.open();
+                    }
                     function toggleFavor(model, index) {
                         if(!index) index = view.currentIndex;
 
@@ -355,6 +367,43 @@ RowLayout {
                     const path = Utils.trimCharR(wpDialog.selectedFolder.toString(), '/');
                     cfg_SteamLibraryPath = path;
                     return wpListModel.refresh();
+                }
+            }
+
+            MessageDialog {
+                id: deleteConfirm
+                property string targetPath: ""
+                property string targetWorkshopId: ""
+                property string targetTitle: ""
+
+                title: "Delete Wallpaper"
+                text: `Delete "${targetTitle}" from disk? This cannot be undone.`
+                buttons: MessageDialog.Yes | MessageDialog.No
+
+                onAccepted: {
+                    if(!targetPath) return;
+                    const path = targetPath;
+                    const wid = targetWorkshopId;
+                    const wasSelected = wid && wid === cfg_WallpaperWorkShopId;
+                    pyext.delete_wallpaper(path, wid).then(res => {
+                        if(res && res.ok) {
+                            if(wasSelected) {
+                                cfg_WallpaperSource = "";
+                                cfg_WallpaperWorkShopId = "";
+                            }
+                            wpListModel.refresh();
+                        } else {
+                            console.error("delete failed:", res ? res.error : "no response");
+                        }
+                    }).catch(reason => console.error("delete error:", reason));
+                    targetPath = "";
+                    targetWorkshopId = "";
+                    targetTitle = "";
+                }
+                onRejected: {
+                    targetPath = "";
+                    targetWorkshopId = "";
+                    targetTitle = "";
                 }
             }
         }
@@ -510,7 +559,13 @@ RowLayout {
                             Kirigami.Action {
                                 icon.source: Qt.resolvedUrl('../../images/folder-outline.svg')
                                 tooltip: "Open Containing Folder"
-                                onTriggered: Qt.openUrlExternally(right_content.wpmodel.path) 
+                                onTriggered: Qt.openUrlExternally(right_content.wpmodel.path)
+                            },
+                            Kirigami.Action {
+                                icon.name: "edit-delete"
+                                tooltip: "Delete from disk"
+                                enabled: Boolean(right_content.wpmodel.path)
+                                onTriggered: picViewLoader.item.requestDelete(right_content.wpmodel)
                             }
                         ]
                     }

--- a/plugin/contents/ui/page/WallpaperPage.qml
+++ b/plugin/contents/ui/page/WallpaperPage.qml
@@ -225,11 +225,6 @@ RowLayout {
                                 tooltip: "Open Workshop Link"
                                 enabled: workshopid.match(Common.regex_workshop_online)
                                 onTriggered: Qt.openUrlExternally(Common.getWorkshopUrl(workshopid))
-                            },
-                            Kirigami.Action {
-                                icon.name: "edit-delete"
-                                tooltip: "Delete from disk"
-                                onTriggered: picViewLoader.item.requestDelete(model)
                             }
                         ]
                         thumbnail: Rectangle {
@@ -336,13 +331,6 @@ RowLayout {
                             resolve();
                         });
                     }
-                    function requestDelete(wpmodel) {
-                        if(!wpmodel || !wpmodel.path) return;
-                        deleteConfirm.targetPath = Common.urlNative(wpmodel.path);
-                        deleteConfirm.targetWorkshopId = wpmodel.workshopid || "";
-                        deleteConfirm.targetTitle = wpmodel.title || wpmodel.workshopid || "";
-                        deleteConfirm.open();
-                    }
                     function toggleFavor(model, index) {
                         if(!index) index = view.currentIndex;
 
@@ -367,43 +355,6 @@ RowLayout {
                     const path = Utils.trimCharR(wpDialog.selectedFolder.toString(), '/');
                     cfg_SteamLibraryPath = path;
                     return wpListModel.refresh();
-                }
-            }
-
-            MessageDialog {
-                id: deleteConfirm
-                property string targetPath: ""
-                property string targetWorkshopId: ""
-                property string targetTitle: ""
-
-                title: "Delete Wallpaper"
-                text: `Delete "${targetTitle}" from disk? This cannot be undone.`
-                buttons: MessageDialog.Yes | MessageDialog.No
-
-                onAccepted: {
-                    if(!targetPath) return;
-                    const path = targetPath;
-                    const wid = targetWorkshopId;
-                    const wasSelected = wid && wid === cfg_WallpaperWorkShopId;
-                    pyext.delete_wallpaper(path, wid).then(res => {
-                        if(res && res.ok) {
-                            if(wasSelected) {
-                                cfg_WallpaperSource = "";
-                                cfg_WallpaperWorkShopId = "";
-                            }
-                            wpListModel.refresh();
-                        } else {
-                            console.error("delete failed:", res ? res.error : "no response");
-                        }
-                    }).catch(reason => console.error("delete error:", reason));
-                    targetPath = "";
-                    targetWorkshopId = "";
-                    targetTitle = "";
-                }
-                onRejected: {
-                    targetPath = "";
-                    targetWorkshopId = "";
-                    targetTitle = "";
                 }
             }
         }
@@ -559,13 +510,7 @@ RowLayout {
                             Kirigami.Action {
                                 icon.source: Qt.resolvedUrl('../../images/folder-outline.svg')
                                 tooltip: "Open Containing Folder"
-                                onTriggered: Qt.openUrlExternally(right_content.wpmodel.path)
-                            },
-                            Kirigami.Action {
-                                icon.name: "edit-delete"
-                                tooltip: "Delete from disk"
-                                enabled: Boolean(right_content.wpmodel.path)
-                                onTriggered: picViewLoader.item.requestDelete(right_content.wpmodel)
+                                onTriggered: Qt.openUrlExternally(right_content.wpmodel.path) 
                             }
                         ]
                     }

--- a/plugin/metadata.desktop
+++ b/plugin/metadata.desktop
@@ -12,4 +12,4 @@ X-KDE-PluginInfo-Name=com.github.catsout.wallpaperEngineKde
 X-KDE-PluginInfo-Author=catsout
 X-KDE-PluginInfo-Category=
 X-KDE-PluginInfo-License=GPLv2+
-X-KDE-PluginInfo-Version=
+X-KDE-PluginInfo-Version=0.5.5

--- a/plugin/metadata.json
+++ b/plugin/metadata.json
@@ -15,7 +15,7 @@
         "ServiceTypes": [
             "Plasma/Wallpaper"
         ],
-        "Version": ""
+        "Version": "0.5.5"
     },
     "X-KDE-ParentApp": "org.kde.plasmashell",
     "X-Plasma-MainScript": "ui/main.qml"

--- a/src/TTYSwitchMonitor.cpp
+++ b/src/TTYSwitchMonitor.cpp
@@ -7,7 +7,8 @@ TTYSwitchMonitor::TTYSwitchMonitor(QQuickItem *parent)
     : QQuickItem(parent), m_sleeping(false) {
     QDBusConnection systemBus = QDBusConnection::systemBus();
     if (!systemBus.isConnected()) {
-        qFatal("Cannot connect to the D-Bus system bus");
+        qWarning() << "TTYSwitchMonitor: Cannot connect to the D-Bus system bus."
+                   << "Sleep/wake detection will be disabled.";
         return;
     }
 
@@ -21,7 +22,8 @@ TTYSwitchMonitor::TTYSwitchMonitor(QQuickItem *parent)
     );
 
     if (!connected) {
-        qFatal("Failed to connect to PrepareForSleep signal");
+        qWarning() << "TTYSwitchMonitor: Failed to connect to PrepareForSleep signal."
+                   << "Sleep/wake detection will be disabled.";
     }
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Wallpaper Engine KDE Plugin - Uninstaller
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $*"; }
+ok()    { echo -e "${GREEN}[ OK ]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERR ]${NC} $*" >&2; }
+die()   { error "$*"; exit 1; }
+
+PLUGIN_ID="com.github.catsout.wallpaperEngineKde"
+QML_SYSTEM_DIR="/usr/lib/qt6/qml/com/github/catsout/wallpaperEngineKde"
+QML_SYSTEM_DIR_ALT="/usr/lib/qt5/qml/com/github/catsout/wallpaperEngineKde"
+PLASMA_USER_DIR="${HOME}/.local/share/plasma/wallpapers/${PLUGIN_ID}"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Wallpaper Engine KDE Plugin – Uninstaller"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Parse flags
+SKIP_RESTART=0
+YES=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip-restart) SKIP_RESTART=1 ;;
+        --yes|-y)       YES=1 ;;
+        --help|-h)
+            echo "Usage: $0 [--yes] [--skip-restart]"
+            echo ""
+            echo "  --yes / -y      Skip confirmation prompt"
+            echo "  --skip-restart  Skip restarting plasmashell after uninstall"
+            exit 0
+            ;;
+    esac
+done
+
+# ── confirm ───────────────────────────────────────────────────────────────────
+if [[ "${YES}" == "0" ]]; then
+    echo "This will remove:"
+    echo "  [system]  ${QML_SYSTEM_DIR}"
+    echo "  [user]    ${PLASMA_USER_DIR}"
+    echo ""
+    read -rp "Proceed? [y/N] " ans
+    [[ "${ans,,}" == "y" ]] || { info "Aborted."; exit 0; }
+    echo ""
+fi
+
+# ── remove system QML plugin (requires sudo) ──────────────────────────────────
+remove_system() {
+    local removed=0
+    for dir in "${QML_SYSTEM_DIR}" "${QML_SYSTEM_DIR_ALT}"; do
+        if [[ -d "${dir}" ]]; then
+            info "Removing system QML plugin: ${dir}"
+            sudo rm -rf "${dir}" \
+                && ok "Removed ${dir}" \
+                || { error "Failed to remove ${dir}"; return 1; }
+            removed=1
+        fi
+    done
+    # Also remove the qmldir parent if now empty
+    [[ "${removed}" == "0" ]] && warn "System QML plugin not found (already uninstalled?)"
+}
+
+# ── remove plasma user package ────────────────────────────────────────────────
+remove_user_pkg() {
+    if [[ -d "${PLASMA_USER_DIR}" ]]; then
+        info "Removing user plasma package: ${PLASMA_USER_DIR}"
+        # Try kpackagetool first (clean unregistration), fall back to rm
+        if command -v kpackagetool6 &>/dev/null; then
+            kpackagetool6 -t Plasma/Wallpaper -r "${PLUGIN_ID}" 2>/dev/null \
+                && ok "Removed via kpackagetool6" \
+                || { warn "kpackagetool6 removal failed, falling back to rm"; rm -rf "${PLASMA_USER_DIR}"; ok "Removed ${PLASMA_USER_DIR}"; }
+        elif command -v kpackagetool &>/dev/null; then
+            kpackagetool -t Plasma/Wallpaper -r "${PLUGIN_ID}" 2>/dev/null \
+                && ok "Removed via kpackagetool" \
+                || { warn "kpackagetool removal failed, falling back to rm"; rm -rf "${PLASMA_USER_DIR}"; ok "Removed ${PLASMA_USER_DIR}"; }
+        else
+            rm -rf "${PLASMA_USER_DIR}"
+            ok "Removed ${PLASMA_USER_DIR}"
+        fi
+    else
+        warn "User plasma package not found (already uninstalled?)"
+    fi
+}
+
+# ── restart plasmashell ───────────────────────────────────────────────────────
+restart_plasma() {
+    info "Restarting plasmashell…"
+    if systemctl --user is-active plasma-plasmashell.service &>/dev/null; then
+        systemctl --user restart plasma-plasmashell.service \
+            && ok "plasmashell restarted." \
+            || warn "Could not restart plasmashell. Please log out and back in."
+    else
+        warn "plasma-plasmashell service not active. Please restart your KDE session."
+    fi
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────
+remove_system
+remove_user_pkg
+
+if [[ "${SKIP_RESTART}" == "0" ]]; then
+    restart_plasma
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+ok "Uninstall complete."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
A few crash fixes that bit me on CachyOS/KDE 6, plus some UX tweaks and a pair of install scripts.

## Crash fixes

**TTYSwitchMonitor** was calling `qFatal()` when it couldn't connect to the D-Bus system bus. That tears down plasmashell entirely — swapped it for `qWarning()` so sleep detection just gets skipped instead.

**main.qml** had two problems:
- `mouseHooker.destroy` was missing `()`, so the old MouseGrabber was never actually destroyed when mouse input was toggled off. It accumulated across reloads.
- `backendLoader.item` can be null briefly during backend transitions. Added guards in `autoPause()` and the pause timer so they don't fire on a null reference.

**Scene.qml** — the `displayModeChanged()` call and volume fade were both wired up before `SceneViewer` had finished its `Component.onCompleted`, which could touch `player` before it existed. Added a `playerReady` flag; everything that talks to the player now checks it first.

## QML fixes

Small bugs in WallpaperPage.qml: typo `cofnig` → `config` in the config save path, a wrong `Object.assign` target that was clobbering the object instead of merging into it, and `reoslve` → `resolve` in a Promise callback.

## UX

- InfoShow (the error screen) got a redesign — was just a wall of yellow text, now shows a proper card with the workshop ID, type, error message, and a recovery command for when a scene wallpaper has crashed KDE and left the config stuck.
- Added a small VULKAN badge on wallpaper thumbnails in the picker so it's obvious at a glance which ones run the in-process renderer. Scene wallpapers carry real risk since a renderer fault kills plasmashell; felt worth surfacing.

## Install scripts

`install.sh` — detects distro, installs deps, builds and installs the plugin. Two bugs fixed vs the draft:
- On Arch/CachyOS the package list had `${KDE_VER:-5}` left in it verbatim, so on KDE 6 it tried to install a package literally called `6`. Removed it.
- `sndio` was missing from the Arch dep list. `libmpv` links `libsndio.so.7` at runtime; without the package installed the plugin fails to load silently and plasmashell crashes trying its fallback wallpapers.

`uninstall.sh` — removes the system QML plugin (needs sudo) and the user plasma package via kpackagetool, then restarts plasmashell.

Also added `CRASH_GUIDE.md` explaining why scene wallpapers can crash KDE and how to recover, and bumped the version to 0.5.5.