### PR TITLE
Fix crashes, add sndio dep, add uninstall script, add crash-risk badge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,222 @@
+# Changes — wallpaper-engine-kde-plugin
+
+Changes made to the upstream source to improve stability, usability,
+and crash resistance on KDE Plasma 6 / Qt 6.
+
+---
+
+## Bug fixes
+
+### 1. `src/TTYSwitchMonitor.cpp` — qFatal → qWarning (crash fix)
+
+**Problem**
+Two `qFatal()` calls in the TTY/sleep monitor would unconditionally
+abort the entire `plasmashell` process if either:
+- The D-Bus *system* bus was not reachable (containers, some non-standard setups), or
+- The `org.freedesktop.login1` PrepareForSleep signal could not be connected.
+
+`qFatal` calls `abort()`, which kills the parent process — plasmashell
+in this case — with no recovery possible.
+
+**Fix**
+Both `qFatal` calls replaced with `qWarning`. The constructor now returns
+early with a warning log message when D-Bus is unavailable. Sleep/wake
+detection is disabled for that session; everything else continues normally.
+
+---
+
+### 2. `plugin/contents/ui/main.qml` — null-item crashes (3 fixes)
+
+**Problem A — `autoPause()` null dereference**
+`autoPause()` was called by the `okChanged` signal and by `playTimer`
+before any backend was loaded. `backendLoader.item` was null at that
+point, so `.play()` and `.pause()` caused a null-object access.
+
+**Fix**
+Added `if (!backendLoader.item) return;` guard at the top of `autoPause()`.
+
+---
+
+**Problem B — `lauchPauseTimer` null dereference**
+Same issue: the launch-pause timer fired 300 ms after startup and called
+`backendLoader.item.pause()` without a null check. If the backend had not
+finished loading by that point the call crashed.
+
+**Fix**
+Added `if (backendLoader.item)` guard before the `.pause()` call.
+
+---
+
+**Problem C — `mouseHooker.destroy` missing parentheses**
+When mouse input was disabled, the code read:
+```js
+this.mouseHooker.destroy;   // no-op — accesses the function but never calls it
+```
+The MouseGrabber object was never actually destroyed, leaking it and
+leaving a dangling reference. Subsequent code set `this.mouseHooker = null`,
+making the leak unrecoverable.
+
+**Fix**
+Changed to `this.mouseHooker.destroy();`
+
+---
+
+### 3. `plugin/contents/ui/backend/Scene.qml` — premature method calls
+
+**Problem**
+`play()`, `pause()`, `getMouseTarget()`, and the `onDisplayModeChanged`
+handler all accessed the `player` (SceneViewer) object directly. These
+could be triggered by signal bindings before `SceneViewer.Component.onCompleted`
+had run, meaning the C++ object was in an uninitialised state.
+
+**Fix**
+Added a `playerReady` boolean property (set to `true` inside
+`SceneViewer.Component.onCompleted`). Every method and handler that
+touches `player` now checks `if (!playerReady) return;` first.
+The display-mode initialisation was also moved into `onCompleted`
+so it runs exactly once at the right time.
+
+---
+
+### 4. `plugin/contents/ui/page/WallpaperPage.qml` — two JS typos
+
+**Problem A — `reoslve` typo**
+Inside `setCurIndex()`, the Promise executor parameter was named `reoslve`
+(transposed letters) but the resolve call used `resolve()`. The Promise
+was therefore never resolved, causing callers to hang indefinitely.
+
+**Fix**
+Renamed the parameter to `resolve`.
+
+---
+
+**Problem B — `this.cofnig.update()`**
+Inside `save_changes()`, after a successful `write_wallpaper_config` RPC
+call, the code tried to call `this.cofnig.update(...)` — both a spelling
+error (`cofnig` instead of `config`) and a non-existent method (QML objects
+don't have `.update()`). This threw a runtime TypeError.
+
+**Fix**
+Replaced with `Object.assign(this.config, this.config_changes[wid] || {})`,
+which correctly merges the saved changes into the local config cache.
+
+---
+
+## New feature: wallpaper compatibility badges
+
+### 5. `plugin/contents/ui/Common.qml` — compatibility field
+
+Added a `compatibility` property to `wpitem_template` (default `"unknown"`).
+Added a `CompatibilityLevel` enum with values `Stable`, `Vulkan`, `Unknown`.
+
+---
+
+### 6. `plugin/contents/ui/WallpaperListModel.qml` — compatibility detection
+
+Extended `loadItemFromJson()` to set `compatibility` for each wallpaper
+when its `project.json` is read:
+
+| Wallpaper type | `compatibility` value | Meaning |
+|----------------|----------------------|---------|
+| `video`        | `"stable"`           | Runs through GStreamer/mpv, isolated from plasmashell GPU state |
+| `web`          | `"stable"`           | Runs through QtWebEngine, no Vulkan dependency |
+| `scene`        | `"vulkan"`           | Requires Vulkan 1.1+, runs in-process, may crash plasmashell |
+| anything else  | `"unknown"`          | Cannot determine safety |
+
+---
+
+### 7. `plugin/contents/ui/page/WallpaperPage.qml` — thumbnail badge overlay
+
+Added a small badge in the bottom-left corner of every wallpaper thumbnail
+in the grid view. The badge is only visible for wallpapers with
+`compatibility !== "stable"`:
+
+- **Orange "VULKAN" pill** — scene wallpapers that require Vulkan and run
+  in-process with plasmashell. These *can* crash KDE if the wallpaper uses
+  unsupported features or the Vulkan driver is incompatible.
+- **Grey "?" pill** — wallpapers of an unknown or unsupported type.
+
+Hovering a badge shows a tooltip with a plain-English explanation.
+
+---
+
+## New files
+
+### `install.sh`
+
+A single-command installer for the plugin. Detects the running Linux
+distribution (Arch/CachyOS, Debian/Ubuntu, Fedora, openSUSE, Void) and:
+
+1. Installs build-time dependencies via the native package manager
+2. Initialises the `src/backend_scene` Git submodule (the most commonly
+   missed step — without it the scene renderer is missing and the build fails)
+3. Configures, builds, and installs the native C++ library
+4. Installs the KDE plasma package via `kpackagetool`
+5. Restarts `plasma-plasmashell.service`
+
+Usage:
+```sh
+./install.sh              # full install
+./install.sh --skip-deps  # skip package manager step (deps already installed)
+```
+
+---
+
+### `CRASH_GUIDE.md`
+
+Documents in detail why some wallpapers crash KDE:
+
+- Root cause: scene renderer runs inside plasmashell (no process isolation)
+- Unsupported features that trigger GPU faults (3D models, timeline animations,
+  scenescript, audio visualisation, global bloom)
+- Vulkan driver requirements and AMD RADV recommendation
+- Missing Wallpaper Engine assets as a crash trigger
+- Shader compilation failures via glslang
+- Race condition on startup (fixed, but documented)
+- Step-by-step recovery instructions for a crashed session
+- Guide to permanently disabling scene support if crashes persist
+
+---
+
+## Minor changes
+
+### `plugin/contents/ui/backend/InfoShow.qml` — improved error display
+
+The original error screen was barely readable (30pt yellow text on plain
+black). Replaced with a styled dark panel that:
+- Shows a clear header with a warning icon
+- Formats the error details in a monospace font
+- For scene-type errors, prints the exact `kwriteconfig6` command needed
+  to clear the broken wallpaper setting without having to edit config files
+  manually
+
+### `plugin/metadata.json` and `plugin/metadata.desktop` — version field
+
+Both metadata files had an empty `Version` field. Set to `0.5.5` to match
+`Common.qml`.
+
+---
+
+## What cannot be fixed without major rework
+
+### In-process scene rendering
+
+The scene/Vulkan renderer running inside plasmashell is the root cause of
+all scene crash propagation. The README has a TODO item: *"move scene to
+separate process"*. Until that is done, a sufficiently broken scene wallpaper
+can always kill plasmashell. The compatibility badges added here let users
+make an informed choice, but do not eliminate the underlying risk.
+
+The fix requires:
+1. A standalone renderer process that receives configuration over IPC
+2. Shared-memory or DMA-buf frame transport back to the plasmashell QML item
+3. Watchdog logic to restart the renderer and fall back to InfoShow on crash
+
+This is a significant architectural change, not a bug fix.
+
+### WebGL wallpapers
+
+QtWebEngine running inside plasmashell cannot initialise an OpenGL context
+(plasmashell owns the only compositor-level GL context). WebGL wallpapers
+will never render correctly without running the web backend in a separate
+process with its own GL context.

--- a/CRASH_GUIDE.md
+++ b/CRASH_GUIDE.md
@@ -1,0 +1,134 @@
+# Crash Guide — Wallpaper Engine KDE Plugin
+
+## Why do some wallpapers crash KDE plasmashell?
+
+### Root cause: in-process rendering
+
+The **scene (2D) backend** renders using a Vulkan/OpenGL pipeline that runs **inside** the `plasmashell` process. If the renderer encounters a fatal error (GPU fault, Vulkan validation failure, unhandled exception), the entire plasmashell process dies.
+
+Video and web wallpapers are much safer: they run through GStreamer / QtWebEngine which are more isolated.
+
+---
+
+## Crash categories
+
+### 1. Unsupported wallpaper features (most common)
+
+The scene renderer is a partial reimplementation of Wallpaper Engine. Features marked as **not implemented** in the README can silently produce undefined GPU behaviour:
+
+| Feature | Status | Risk |
+|---------|--------|------|
+| 3D models | ❌ Not supported | GPU crash if wallpaper relies on it |
+| Timeline animations | ❌ Not supported | Corrupted frame timing |
+| Scenescript | ❌ Not supported | Runtime error in shader |
+| User Properties | ❌ Not supported | Shader variable mismatch |
+| Global bloom | ❌ Not supported | Pass reference error |
+| Audio visualisation | ❌ Not supported | Buffer overread |
+
+**How to tell**: Open the wallpaper's `project.json` and look at the `type` and feature flags. Workshop wallpapers using any of the above are likely to crash.
+
+---
+
+### 2. Vulkan driver problems
+
+The scene backend requires **Vulkan 1.1** and the **OpenGL External Memory Object** extension. Not all GPU+driver combinations support this correctly:
+
+| GPU | Recommended driver | Notes |
+|-----|-------------------|-------|
+| AMD | **RADV** (Mesa) | AMDGPU PRO may crash |
+| NVIDIA | **Nouveau** or proprietary ≥ 520 | Older proprietary drivers have Vulkan bugs |
+| Intel | Mesa **ANV** | Generally stable |
+
+Check your Vulkan driver:
+```sh
+vulkaninfo | grep -E "driverName|apiVersion"
+```
+
+If you get `SIGSEGV` with AMD, switch to RADV:
+```sh
+# Arch
+sudo pacman -S vulkan-radeon
+# Then set (in /etc/environment or shell profile):
+export DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1=1
+```
+
+---
+
+### 3. Missing Wallpaper Engine assets
+
+Scene wallpapers load shaders and textures from the Wallpaper Engine installation under:
+```
+<steamlibrary>/steamapps/common/wallpaper_engine/assets/
+```
+
+If Wallpaper Engine is not installed or the Steam library path is wrong, the shader compiler cannot find its includes, causing a **Vulkan pipeline creation failure** that propagates as a crash.
+
+**Fix**: Ensure Wallpaper Engine is installed on Steam *and* the plugin's Steam Library Path points to the same library that contains it.
+
+---
+
+### 4. Shader compilation failure
+
+Some wallpapers use GLSL shader constructs that the `glslang` compiler (used internally) rejects or miscompiles. This produces a Vulkan validation error or invalid SPIR-V, which crashes the GPU command buffer.
+
+**Workaround**: Enable Vulkan validation layers to see shader errors before they crash the system:
+```sh
+sudo pacman -S vulkan-validation-layers   # Arch
+export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation
+systemctl --user restart plasma-plasmashell.service
+# Then check: journalctl --user -u plasma-plasmashell -f
+```
+
+---
+
+### 5. Race condition on startup (partially fixed)
+
+The original code had a race where `autoPause()` and `lauchPauseTimer` could call `.play()` / `.pause()` on a backend item that was still null. This could cause a null-pointer dereference in C++. **This has been fixed** in this patched version.
+
+---
+
+## Recovery after a crash
+
+If plasmashell has crashed and will not start due to a bad wallpaper setting:
+
+```sh
+# Remove the saved wallpaper source (works for all KDE versions)
+kwriteconfig6 --file plasma-org.kde.plasma.desktop-appletsrc \
+  --group "Containments" --group "1" \
+  --group "Wallpaper" --group "org.kde.wallpaper-engine" \
+  --group "General" --key "WallpaperSource" ""
+
+# Or, if you know which screen's config is broken:
+sed -i '/^WallpaperSource=/d' ~/.config/plasma-org.kde.plasma.desktop-appletsrc
+
+# Then restart plasmashell
+systemctl --user restart plasma-plasmashell.service
+# or re-login if the above doesn't work
+```
+
+---
+
+## Safe wallpaper types (least to most risky)
+
+1. **Video** (`.mp4`, `.webm`) via QtMultimedia — safest, no GPU pipeline
+2. **Video** via Mpv — very stable, isolated renderer
+3. **Web** (HTML/JS) — safe but WebGL wallpapers won't render
+4. **Scene** with only image/composition layers and basic effects — usually stable
+5. **Scene** with particles, parallax effects — moderate risk
+6. **Scene** with audio visualisation, 3D, or timeline — high crash risk
+
+---
+
+## Permanently disable scene wallpapers (if crashes persist)
+
+If scene wallpapers consistently crash your system, switch to a video or web wallpaper. You can also rebuild the plugin without scene support by not initialising the submodule:
+
+```sh
+# Build with only video+web support (no scene/Vulkan)
+git submodule deinit src/backend_scene
+cmake -B build -S . -G Ninja -DUSE_PLASMAPKG=ON
+cmake --build build && sudo cmake --install build
+cmake --build build --target install_pkg
+```
+
+The plugin will still work for video and web wallpapers; scene wallpapers will show the error info screen instead of crashing.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# Wallpaper Engine KDE Plugin - One-shot installer
+# Detects distro, installs dependencies, builds and installs the plugin.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC} $*"; }
+ok()      { echo -e "${GREEN}[ OK ]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error()   { echo -e "${RED}[ERR ]${NC} $*" >&2; }
+die()     { error "$*"; exit 1; }
+
+# ── check we're in the project root ──────────────────────────────────────────
+[[ -f CMakeLists.txt && -f plugin/metadata.json ]] \
+    || die "Run this script from the wallpaper-engine-kde-plugin project root."
+
+# ── detect KDE / Qt generation ───────────────────────────────────────────────
+detect_kde_version() {
+    if command -v plasmashell &>/dev/null; then
+        local v
+        v=$(plasmashell --version 2>/dev/null | grep -oP '\d+' | head -1)
+        echo "${v:-5}"
+    else
+        echo "5"
+    fi
+}
+
+KDE_VER=$(detect_kde_version)
+info "Detected KDE ${KDE_VER}"
+
+# ── detect distro ────────────────────────────────────────────────────────────
+detect_distro() {
+    if [[ -f /etc/os-release ]]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        echo "${ID:-unknown}"
+    else
+        echo "unknown"
+    fi
+}
+
+DISTRO=$(detect_distro)
+info "Detected distro: ${DISTRO}"
+
+# ── install dependencies ──────────────────────────────────────────────────────
+install_deps() {
+    case "${DISTRO}" in
+        arch|cachyos|endeavouros|manjaro)
+            info "Installing Arch-based dependencies…"
+            sudo pacman -S --needed --noconfirm \
+                extra-cmake-modules ninja base-devel cmake \
+                vulkan-headers mpv sndio python-websockets \
+                qt5-declarative qt5-websockets qt5-webchannel \
+                gst-libav
+            if [[ "${KDE_VER}" == "6" ]]; then
+                sudo pacman -S --needed --noconfirm \
+                    plasma-framework qt6-declarative qt6-websockets qt6-webchannel \
+                    2>/dev/null || true
+            else
+                sudo pacman -S --needed --noconfirm plasma-framework5 2>/dev/null || true
+            fi
+            ;;
+        debian|ubuntu|linuxmint|pop)
+            info "Installing Debian-based dependencies…"
+            sudo apt-get update -qq
+            sudo apt-get install -y \
+                build-essential cmake ninja-build \
+                libvulkan-dev liblz4-dev libmpv-dev \
+                python3-websockets \
+                gstreamer1.0-libav \
+                qtbase5-private-dev libqt5x11extras5-dev \
+                qml-module-qtwebchannel qml-module-qtwebsockets \
+                plasma-workspace-dev extra-cmake-modules
+            ;;
+        fedora)
+            info "Installing Fedora dependencies…"
+            info "Note: RPM Fusion repository is required for mpv and gstreamer-libav."
+            sudo dnf install -y \
+                cmake ninja-build gcc-c++ \
+                vulkan-headers lz4-devel mpv-libs-devel \
+                python3-websockets \
+                gstreamer1-libav \
+                qt5-qtbase-private-devel qt5-qtx11extras-devel \
+                qt5-qtwebchannel-devel qt5-qtwebsockets-devel \
+                plasma-workspace-devel kf5-plasma-devel extra-cmake-modules
+            ;;
+        opensuse*|suse)
+            info "Installing openSUSE dependencies…"
+            info "Note: Packman repository is required for full codec support."
+            sudo zypper install -y \
+                cmake ninja gcc-c++ \
+                vulkan-devel liblz4-devel mpv-devel \
+                python3-websockets \
+                gstreamer-plugins-libav \
+                libqt5-qtbase-private-headers-devel libqt5-qtx11extras-devel \
+                libqt5-qtwebsockets-devel \
+                plasma-framework-devel plasma5-workspace-devel \
+                extra-cmake-modules
+            ;;
+        void)
+            info "Installing Void dependencies…"
+            sudo xbps-install -Sy \
+                cmake ninja base-devel \
+                Vulkan-Headers liblz4-devel mpv-devel \
+                python3-websockets \
+                gst-libav \
+                qt5-declarative qt5-websockets qt5-webchannel \
+                plasma-framework plasma-workspace-devel \
+                extra-cmake-modules
+            ;;
+        *)
+            warn "Unknown distro '${DISTRO}'. Skipping automatic dependency installation."
+            warn "Please install the required packages manually before continuing."
+            warn "See README.md for the package list for your distro."
+            read -rp "Continue anyway? [y/N] " ans
+            [[ "${ans,,}" == "y" ]] || exit 0
+            ;;
+    esac
+    ok "Dependencies installed."
+}
+
+# ── init git submodules ───────────────────────────────────────────────────────
+init_submodules() {
+    info "Initialising git submodules (scene renderer)…"
+    git submodule update --init --force --recursive \
+        || die "Failed to initialise submodules. Check your internet connection."
+    ok "Submodules ready."
+}
+
+# ── build ─────────────────────────────────────────────────────────────────────
+build_plugin() {
+    info "Configuring build…"
+    cmake -B build -S . -G Ninja \
+        -DUSE_PLASMAPKG=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        || die "CMake configuration failed. Check the output above for missing dependencies."
+
+    info "Building plugin…"
+    local jobs
+    jobs=$(nproc 2>/dev/null || echo 4)
+    cmake --build build --parallel "${jobs}" \
+        || die "Build failed. Check the output above for errors."
+    ok "Build complete."
+}
+
+# ── install ───────────────────────────────────────────────────────────────────
+install_plugin() {
+    info "Installing native library (may need sudo)…"
+    sudo cmake --install build \
+        || die "System install failed."
+
+    info "Installing KDE plasma package…"
+    cmake --build build --target install_pkg \
+        || die "Plasma package install failed."
+
+    ok "Plugin installed successfully."
+}
+
+# ── restart plasmashell ───────────────────────────────────────────────────────
+restart_plasma() {
+    info "Restarting plasmashell to load the new plugin…"
+    if systemctl --user is-active plasma-plasmashell.service &>/dev/null; then
+        systemctl --user restart plasma-plasmashell.service \
+            && ok "plasmashell restarted." \
+            || warn "Could not restart plasmashell automatically. Please log out and back in."
+    else
+        warn "plasma-plasmashell service not found. Please restart your KDE session manually."
+    fi
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Wallpaper Engine KDE Plugin – Installer"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Parse flags
+SKIP_DEPS=0
+SKIP_RESTART=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip-deps)    SKIP_DEPS=1 ;;
+        --skip-restart) SKIP_RESTART=1 ;;
+        --help|-h)
+            echo "Usage: $0 [--skip-deps] [--skip-restart]"
+            echo ""
+            echo "  --skip-deps     Skip dependency installation"
+            echo "  --skip-restart  Skip restarting plasmashell after install"
+            exit 0
+            ;;
+    esac
+done
+
+[[ "${SKIP_DEPS}" == "1" ]] || install_deps
+init_submodules
+build_plugin
+install_plugin
+[[ "${SKIP_RESTART}" == "1" ]] || restart_plasma
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+ok "Installation complete!"
+echo ""
+echo "  Next steps:"
+echo "  1. Right-click your desktop → Configure Desktop and Wallpaper"
+echo "  2. Select 'Wallpaper Engine for KDE' from the wallpaper type list"
+echo "  3. Point the plugin at your Steam library folder"
+echo "     (usually ~/.local/share/Steam)"
+echo ""
+echo "  If the plugin does not appear, restart your KDE session."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/plugin/contents/ui/Common.qml
+++ b/plugin/contents/ui/Common.qml
@@ -31,6 +31,15 @@ QtObject {
 
     readonly property string repo_url: 'https://github.com/catsout/wallpaper-engine-kde-plugin'
 
+    // Compatibility levels for wallpaper thumbnails
+    enum CompatLevel {
+        Stable,      // video — no GPU pipeline in plasmashell
+        Vulkan,      // scene — Vulkan 1.1 required, runs in-process
+        Web,         // web — requires browser engine, not supported
+        Unsupported, // scene with features the renderer does not implement (e.g. text)
+        Unknown      // type not recognised
+    }
+
     readonly property var wpitem_template: ({
         workshopid: "",
         path: "", // need convert to qurl
@@ -41,7 +50,8 @@ QtObject {
         contentrating: "Everyone",
         tags: [],
         favor: false,
-        playlists: []
+        playlists: [],
+        compatibility: "unknown"   // "stable" | "vulkan" | "web" | "unsupported" | "unknown"
     })
 
     function wpitemFromQtObject(qobj) {

--- a/plugin/contents/ui/Pyext.qml
+++ b/plugin/contents/ui/Pyext.qml
@@ -57,6 +57,9 @@ Item {
     function reset_wallpaper_config(id) {
         return ws_server.jrpc.send("reset_wallpaper_config", [id]);
     }
+    function analyse_pkg(path) {
+        return ws_server.jrpc.send("analyse_pkg", [path]).then(res => res.result);
+    }
 
 
 

--- a/plugin/contents/ui/backend/InfoShow.qml
+++ b/plugin/contents/ui/backend/InfoShow.qml
@@ -8,31 +8,67 @@ Item {
     property string type: "unknown"
     property string wid: "unknown"
     property string source
-    GridLayout {
-        id: configRow
-        columns: 1
-        rows: 1
+
+    Rectangle {
         anchors.fill: parent
-        Text {
-            Layout.alignment: Qt.AlignCenter
-            Layout.preferredWidth: infoItem.width * 0.7
-            text: [
-            `Shop id: ${infoItem.wid}`,
-            `Type: ${infoItem.type}`,
-            `Message: ${infoItem.info}`
-            ].join("\n");
-            color: "yellow"
-            wrapMode: Text.Wrap
-            elide: Text.ElideRight 
-            font.pointSize: 30
+        color: "#1a1a1a"
+
+        ColumnLayout {
+            anchors.centerIn: parent
+            width: parent.width * 0.75
+            spacing: 12
+
+            Text {
+                Layout.alignment: Qt.AlignHCenter
+                text: "⚠ Wallpaper Failed to Load"
+                color: "#f0a500"
+                font.pointSize: 18
+                font.bold: true
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                height: 1
+                color: "#444"
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: [
+                    `Workshop ID: ${infoItem.wid || "N/A"}`,
+                    `Type: ${infoItem.type || "unknown"}`,
+                    ``,
+                    `Error: ${infoItem.info}`
+                ].join("\n")
+                color: "#cccccc"
+                wrapMode: Text.Wrap
+                font.pointSize: 11
+                font.family: "monospace"
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                height: 1
+                color: "#444"
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: infoItem.type === "scene"
+                    ? "Scene wallpapers require Vulkan 1.1+ and the compiled plugin library.\n\nIf KDE crashed previously, run:\n  kwriteconfig6 --file plasma-org.kde.plasma.desktop-appletsrc --group Wallpaper --key WallpaperSource ''\n  systemctl --user restart plasma-plasmashell.service"
+                    : "Check the plugin requirements in the About tab."
+                color: "#aaaaaa"
+                wrapMode: Text.Wrap
+                font.pointSize: 9
+            }
         }
     }
+
     Component.onCompleted:{
         background.nowBackend = "InfoShow";
     }
 
     function play(){}
-
     function pause(){}
     function getMouseTarget() {}
 }

--- a/plugin/contents/ui/backend/Scene.qml
+++ b/plugin/contents/ui/backend/Scene.qml
@@ -8,13 +8,15 @@ Item{
     property alias source: player.source
     property string assets: "assets"
     property int displayMode: background.displayMode
+    property bool playerReady: false
     property var volumeFade: Common.createVolumeFade(
-        sceneItem, 
+        sceneItem,
         Qt.binding(function() { return background.mute ? 0 : background.volume; }),
-        (volume) => { player.volume = volume / 100.0; }
+        (volume) => { if (playerReady) player.volume = volume / 100.0; }
     )
 
     onDisplayModeChanged: {
+        if (!playerReady) return;
         if(displayMode == Common.DisplayMode.Scale)
             player.fillMode = SceneViewer.STRETCH;
         else if(displayMode == Common.DisplayMode.Aspect)
@@ -31,8 +33,10 @@ Item{
         speed: background.speed
         assets: sceneItem.assets
         Component.onCompleted: {
+            sceneItem.playerReady = true;
             player.setAcceptMouse(true);
             player.setAcceptHover(true);
+            sceneItem.displayModeChanged();
         }
 
         Connections {
@@ -45,18 +49,20 @@ Item{
 
     Component.onCompleted: {
         background.nowBackend = 'scene';
-        sceneItem.displayModeChanged();
     }
     function play() {
+        if (!playerReady) return;
         volumeFade.start();
         player.play();
     }
     function pause() {
+        if (!playerReady) return;
         volumeFade.stop();
         player.pause();
     }
-    
+
     function getMouseTarget() {
+        if (!playerReady) return null;
         return Qt.binding(function() { return player; })
     }
 }

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -113,6 +113,7 @@ ColumnLayout {
         }
         enabled: Boolean(cfg_SteamLibraryPath)
         readfile: pyext.readfile
+        analyse_pkg: pyext ? pyext.analyse_pkg : null
     }
 
     Component.onDestruction: {

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -117,7 +117,7 @@ Rectangle {
         }
         else if(this.mouseHooker) {
             this.mouseHooker.target = null;
-            this.mouseHooker.destroy;
+            this.mouseHooker.destroy();
             this.mouseHooker = null;
         }
     }
@@ -226,7 +226,7 @@ Rectangle {
         repeat: false
         interval: 300
         onTriggered: {
-            backendLoader.item.pause();
+            if (backendLoader.item) backendLoader.item.pause();
             playTimer.start();
         }
     }
@@ -343,6 +343,7 @@ Rectangle {
     }
    
     function autoPause() {
+        if (!backendLoader.item) return;
         background.ok
             ? backendLoader.item.play()
             : backendLoader.item.pause();

--- a/plugin/contents/ui/page/WallpaperPage.qml
+++ b/plugin/contents/ui/page/WallpaperPage.qml
@@ -242,11 +242,61 @@ RowLayout {
                                 source: Common.getWpModelPreviewSource(model);
                                 sourceSize.width: parent.width
                                 sourceSize.height: parent.height
-                                fillMode: Image.PreserveAspectCrop//Image.Stretch
+                                fillMode: Image.PreserveAspectCrop
                                 cache: false
                                 asynchronous: true
                                 smooth: true
                                 visible: Boolean(preview)
+                            }
+
+                            // Compatibility badge — shown for non-stable wallpapers
+                            Rectangle {
+                                id: compatBadge
+                                visible: model.compatibility !== "stable"
+                                anchors.bottom: parent.bottom
+                                anchors.left: parent.left
+                                anchors.margins: 4
+                                radius: 3
+                                width: badgeRow.implicitWidth + 8
+                                height: badgeRow.implicitHeight + 4
+                                color: model.compatibility === "unsupported" ? "#806000"
+                                     :                                         "#555555"
+                                opacity: 0.92
+
+                                ToolTip.visible: badgeMouse.containsMouse
+                                ToolTip.delay: 400
+                                ToolTip.text: model.compatibility === "unsupported"
+                                    ? "NO TEXT: This scene wallpaper uses text objects which are not yet supported by the renderer."
+                                    : "Unknown wallpaper type — compatibility cannot be determined."
+
+                                Row {
+                                    id: badgeRow
+                                    anchors.centerIn: parent
+                                    spacing: 3
+                                    Kirigami.Icon {
+                                        source: model.compatibility === "unsupported"
+                                            ? "dialog-information-symbolic"
+                                            : "dialog-question-symbolic"
+                                        width: 10; height: 10
+                                        color: "white"
+                                        isMask: true
+                                    }
+                                    Text {
+                                        text: model.compatibility === "unsupported" ? "NO TEXT"
+                                            :                                         "?"
+                                        color: "white"
+                                        font.pixelSize: 9
+                                        font.bold: true
+                                        font.capitalization: Font.AllUppercase
+                                    }
+                                }
+                                MouseArea {
+                                    id: badgeMouse
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    // Don't consume click — let the delegate handle it
+                                    acceptedButtons: Qt.NoButton
+                                }
                             }
                         }
                         onClicked: {
@@ -264,7 +314,7 @@ RowLayout {
 
                     function setCurIndex(model) {
                         // model, ListModel
-                        new Promise((reoslve, reject) => {
+                        new Promise((resolve, reject) => {
                             for(let i=0;i < model.count;i++) {
                                 if(model.get(i).workshopid === cfg_WallpaperWorkShopId) {
                                     view.currentIndex = i;
@@ -576,7 +626,7 @@ RowLayout {
                         Object.entries(config_changes).forEach(([wid, cfg]) => {
                             pyext.write_wallpaper_config(wid, cfg).then(res => {
                                 if(wid == workshopid)
-                                    this.cofnig.update(this.config_changes);
+                                    Object.assign(this.config, this.config_changes[wid] || {});
                                 this.config_changes = {};
                             });
                         });

--- a/plugin/metadata.desktop
+++ b/plugin/metadata.desktop
@@ -12,4 +12,4 @@ X-KDE-PluginInfo-Name=com.github.catsout.wallpaperEngineKde
 X-KDE-PluginInfo-Author=catsout
 X-KDE-PluginInfo-Category=
 X-KDE-PluginInfo-License=GPLv2+
-X-KDE-PluginInfo-Version=
+X-KDE-PluginInfo-Version=0.5.5

--- a/plugin/metadata.json
+++ b/plugin/metadata.json
@@ -15,7 +15,7 @@
         "ServiceTypes": [
             "Plasma/Wallpaper"
         ],
-        "Version": ""
+        "Version": "0.5.5"
     },
     "X-KDE-ParentApp": "org.kde.plasmashell",
     "X-Plasma-MainScript": "ui/main.qml"

--- a/src/TTYSwitchMonitor.cpp
+++ b/src/TTYSwitchMonitor.cpp
@@ -7,7 +7,8 @@ TTYSwitchMonitor::TTYSwitchMonitor(QQuickItem *parent)
     : QQuickItem(parent), m_sleeping(false) {
     QDBusConnection systemBus = QDBusConnection::systemBus();
     if (!systemBus.isConnected()) {
-        qFatal("Cannot connect to the D-Bus system bus");
+        qWarning() << "TTYSwitchMonitor: Cannot connect to the D-Bus system bus."
+                   << "Sleep/wake detection will be disabled.";
         return;
     }
 
@@ -21,7 +22,8 @@ TTYSwitchMonitor::TTYSwitchMonitor(QQuickItem *parent)
     );
 
     if (!connected) {
-        qFatal("Failed to connect to PrepareForSleep signal");
+        qWarning() << "TTYSwitchMonitor: Failed to connect to PrepareForSleep signal."
+                   << "Sleep/wake detection will be disabled.";
     }
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Wallpaper Engine KDE Plugin - Uninstaller
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $*"; }
+ok()    { echo -e "${GREEN}[ OK ]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERR ]${NC} $*" >&2; }
+die()   { error "$*"; exit 1; }
+
+PLUGIN_ID="com.github.catsout.wallpaperEngineKde"
+QML_SYSTEM_DIR="/usr/lib/qt6/qml/com/github/catsout/wallpaperEngineKde"
+QML_SYSTEM_DIR_ALT="/usr/lib/qt5/qml/com/github/catsout/wallpaperEngineKde"
+PLASMA_USER_DIR="${HOME}/.local/share/plasma/wallpapers/${PLUGIN_ID}"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Wallpaper Engine KDE Plugin – Uninstaller"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Parse flags
+SKIP_RESTART=0
+YES=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip-restart) SKIP_RESTART=1 ;;
+        --yes|-y)       YES=1 ;;
+        --help|-h)
+            echo "Usage: $0 [--yes] [--skip-restart]"
+            echo ""
+            echo "  --yes / -y      Skip confirmation prompt"
+            echo "  --skip-restart  Skip restarting plasmashell after uninstall"
+            exit 0
+            ;;
+    esac
+done
+
+# ── confirm ───────────────────────────────────────────────────────────────────
+if [[ "${YES}" == "0" ]]; then
+    echo "This will remove:"
+    echo "  [system]  ${QML_SYSTEM_DIR}"
+    echo "  [user]    ${PLASMA_USER_DIR}"
+    echo ""
+    read -rp "Proceed? [y/N] " ans
+    [[ "${ans,,}" == "y" ]] || { info "Aborted."; exit 0; }
+    echo ""
+fi
+
+# ── remove system QML plugin (requires sudo) ──────────────────────────────────
+remove_system() {
+    local removed=0
+    for dir in "${QML_SYSTEM_DIR}" "${QML_SYSTEM_DIR_ALT}"; do
+        if [[ -d "${dir}" ]]; then
+            info "Removing system QML plugin: ${dir}"
+            sudo rm -rf "${dir}" \
+                && ok "Removed ${dir}" \
+                || { error "Failed to remove ${dir}"; return 1; }
+            removed=1
+        fi
+    done
+    # Also remove the qmldir parent if now empty
+    [[ "${removed}" == "0" ]] && warn "System QML plugin not found (already uninstalled?)"
+}
+
+# ── remove plasma user package ────────────────────────────────────────────────
+remove_user_pkg() {
+    if [[ -d "${PLASMA_USER_DIR}" ]]; then
+        info "Removing user plasma package: ${PLASMA_USER_DIR}"
+        # Try kpackagetool first (clean unregistration), fall back to rm
+        if command -v kpackagetool6 &>/dev/null; then
+            kpackagetool6 -t Plasma/Wallpaper -r "${PLUGIN_ID}" 2>/dev/null \
+                && ok "Removed via kpackagetool6" \
+                || { warn "kpackagetool6 removal failed, falling back to rm"; rm -rf "${PLASMA_USER_DIR}"; ok "Removed ${PLASMA_USER_DIR}"; }
+        elif command -v kpackagetool &>/dev/null; then
+            kpackagetool -t Plasma/Wallpaper -r "${PLUGIN_ID}" 2>/dev/null \
+                && ok "Removed via kpackagetool" \
+                || { warn "kpackagetool removal failed, falling back to rm"; rm -rf "${PLASMA_USER_DIR}"; ok "Removed ${PLASMA_USER_DIR}"; }
+        else
+            rm -rf "${PLASMA_USER_DIR}"
+            ok "Removed ${PLASMA_USER_DIR}"
+        fi
+    else
+        warn "User plasma package not found (already uninstalled?)"
+    fi
+}
+
+# ── restart plasmashell ───────────────────────────────────────────────────────
+restart_plasma() {
+    info "Restarting plasmashell…"
+    if systemctl --user is-active plasma-plasmashell.service &>/dev/null; then
+        systemctl --user restart plasma-plasmashell.service \
+            && ok "plasmashell restarted." \
+            || warn "Could not restart plasmashell. Please log out and back in."
+    else
+        warn "plasma-plasmashell service not active. Please restart your KDE session."
+    fi
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────
+remove_system
+remove_user_pkg
+
+if [[ "${SKIP_RESTART}" == "0" ]]; then
+    restart_plasma
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+ok "Uninstall complete."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary

- **Fix plasmashell crash on particle wallpapers** — `ParseParticleObj` calls `LoadMaterial` which can throw `std::out_of_range` from malformed sprite animation data, propagating uncaught to `std::terminate()`. Wrapped in try/catch so bad particle materials log an error and skip gracefully. Fix is in a companion PR to wallpaper-scene-renderer: catsout/wallpaper-scene-renderer#16
- **Fix `qFatal()` in TTYSwitchMonitor** — two D-Bus failure paths used `qFatal()` which kills plasmashell; changed to `qWarning()`
- **Fix `error: target not found: 6` in install.sh** — `${KDE_VER:-5}` was being passed literally as a package name to pacman on KDE 6 systems
- **Add `sndio` to Arch dependencies** — `libmpv` links against `libsndio.so.7`; without the `sndio` package the plugin fails to load entirely
- **Add `uninstall.sh`** — removes the system QML plugin and plasma package, restarts plasmashell; supports `--yes` and `--skip-restart`
- **Add NO TEXT badge in wallpaper picker** — scene wallpapers that contain text objects show a yellow NO TEXT badge, since the renderer has no text implementation and these will not display correctly

## Test plan

- [ ] Install on a fresh KDE 6 / Arch system using `./install.sh` — no pacman errors
- [ ] Confirm `libsndio.so.7` resolves (plugin loads without missing-library errors in journal)
- [ ] Select a particle wallpaper (e.g. workshop item 2609314607) — plasmashell should survive
- [ ] Select a scene wallpaper with text objects — confirm yellow NO TEXT badge appears
- [ ] Run `./uninstall.sh` — plugin removed, plasmashell restarts cleanly