### PR TITLE
Adjustments to atomic fedora install instructions.

### DIFF
--- a/rpm/README.md
+++ b/rpm/README.md
@@ -7,7 +7,8 @@ toolbox create && toolbox enter
 # Add build dependencies
 sudo dnf install vulkan-headers plasma-workspace-devel kf6-plasma-devel gstreamer1-libav \
 lz4-devel mpv-libs-devel python3-websockets qt6-qtbase-private-devel libplasma-devel \
-qt5-qtx11extras-devel qt6-qtwebchannel-devel qt6-qtwebsockets-devel cmake ninja rpmbuild extra-cmake-modules
+qt5-qtx11extras-devel qt6-qtwebchannel-devel qt6-qtwebsockets-devel cmake ninja rpmbuild extra-cmake-modules \
+kf6-kcoreaddons-devel
 
 # Clone repo
 git clone https://github.com/catsout/wallpaper-engine-kde-plugin.git
@@ -25,7 +26,10 @@ rpmbuild --define="commit $(git rev-parse HEAD)" \
     --undefine=_disable_source_fetch \
     -ba ./rpm/wek.spec
 
+# Exit toolbox
+logout
+
 # Install package
 cd ~/rpmbuild/RPMS/x86_64
-rpm-ostree install --uninstall=wallpaper-engine-kde-plugin ./<select-rpm-to-install>.rpm
+rpm-ostree install ./<select-rpm-to-install>.rpm # add --uninstall=wallpaper-engine-kde-plugin if updating
 ```

--- a/rpm/README.md
+++ b/rpm/README.md
@@ -28,8 +28,12 @@ rpmbuild --define="commit $(git rev-parse HEAD)" \
 
 # Exit toolbox
 logout
+rpm-ostree
+
+# if youre updating do this
+rpm-ostree uninistall wallpaper-engine-kde-plugin
 
 # Install package
 cd ~/rpmbuild/RPMS/x86_64
-rpm-ostree install ./<select-rpm-to-install>.rpm # add --uninstall=wallpaper-engine-kde-plugin if updating
+rpm-ostree install ./<select-newley-created-rpm-to-install>.rpm 
 ```

--- a/rpm/README.md
+++ b/rpm/README.md
@@ -28,12 +28,11 @@ rpmbuild --define="commit $(git rev-parse HEAD)" \
 
 # Exit toolbox
 logout
-rpm-ostree
 
 # if youre updating do this
 rpm-ostree uninistall wallpaper-engine-kde-plugin
 
 # Install package
 cd ~/rpmbuild/RPMS/x86_64
-rpm-ostree install ./<select-newley-created-rpm-to-install>.rpm 
+rpm-ostree install ./<select-newly-created-rpm-to-install>.rpm 
 ```


### PR DESCRIPTION
added a new dependency and improved wording for unaware users. Separated `--uninstall wallpaper-engine-kde-plugin` from rpm-ostree install, since this will fail the command if the plugin isn't installed.