### PR TITLE
Add delete-wallpaper action to the wallpaper picker

### DIFF
--- a/plugin/contents/pyext.py
+++ b/plugin/contents/pyext.py
@@ -7,6 +7,7 @@ import base64
 import math
 import os
 import platform
+import shutil
 
 from pathlib import Path
 
@@ -51,6 +52,11 @@ class Main:
     def reset_wallpaper_config(self, id: str) -> None:
         cfg_file: Path = self.__wallpaper_config_file(id)
         cfg_file.unlink()
+
+    def delete_wallpaper_config(self, id: str) -> None:
+        cfg_file: Path = self.__wallpaper_config_file(id)
+        if cfg_file.exists():
+            cfg_file.unlink()
 
 class Jsonrpc:
     def __init__(self):
@@ -148,6 +154,25 @@ get_folder_list.default_opt = {"only_dir": True, "fallbacks": []}
 jrpc.add_method(M.read_wallpaper_config)
 jrpc.add_method(M.write_wallpaper_config)
 jrpc.add_method(M.reset_wallpaper_config)
+
+
+@jrpc.add_method
+def delete_wallpaper(path: str, workshopid: str = "") -> dict:
+    # Safety: require the target to be an existing directory containing
+    # a project.json file so arbitrary paths can't be wiped out.
+    try:
+        folder: Path = Path(path).resolve()
+        if not folder.is_dir():
+            return {"ok": False, "error": "not a directory"}
+        if not (folder / "project.json").is_file():
+            return {"ok": False, "error": "not a wallpaper folder"}
+        shutil.rmtree(folder)
+        if workshopid:
+            M.delete_wallpaper_config(workshopid)
+        return {"ok": True}
+    except Exception as e:
+        return {"ok": False, "error": repr(e)}
+
 
 async def connect(uri):
     async with websockets.connect(uri) as websocket:

--- a/plugin/contents/ui/Pyext.qml
+++ b/plugin/contents/ui/Pyext.qml
@@ -57,6 +57,9 @@ Item {
     function reset_wallpaper_config(id) {
         return ws_server.jrpc.send("reset_wallpaper_config", [id]);
     }
+    function delete_wallpaper(path, workshopid) {
+        return ws_server.jrpc.send("delete_wallpaper", [path, workshopid || ""]).then(res => res.result);
+    }
 
 
 

--- a/plugin/contents/ui/page/WallpaperPage.qml
+++ b/plugin/contents/ui/page/WallpaperPage.qml
@@ -225,6 +225,11 @@ RowLayout {
                                 tooltip: "Open Workshop Link"
                                 enabled: workshopid.match(Common.regex_workshop_online)
                                 onTriggered: Qt.openUrlExternally(Common.getWorkshopUrl(workshopid))
+                            },
+                            Kirigami.Action {
+                                icon.name: "edit-delete"
+                                tooltip: "Delete from disk"
+                                onTriggered: picViewLoader.item.requestDelete(model)
                             }
                         ]
                         thumbnail: Rectangle {
@@ -281,6 +286,13 @@ RowLayout {
                             resolve();
                         });
                     }
+                    function requestDelete(wpmodel) {
+                        if(!wpmodel || !wpmodel.path) return;
+                        deleteConfirm.targetPath = Common.urlNative(wpmodel.path);
+                        deleteConfirm.targetWorkshopId = wpmodel.workshopid || "";
+                        deleteConfirm.targetTitle = wpmodel.title || wpmodel.workshopid || "";
+                        deleteConfirm.open();
+                    }
                     function toggleFavor(model, index) {
                         if(!index) index = view.currentIndex;
 
@@ -305,6 +317,43 @@ RowLayout {
                     const path = Utils.trimCharR(wpDialog.selectedFolder.toString(), '/');
                     cfg_SteamLibraryPath = path;
                     return wpListModel.refresh();
+                }
+            }
+
+            MessageDialog {
+                id: deleteConfirm
+                property string targetPath: ""
+                property string targetWorkshopId: ""
+                property string targetTitle: ""
+
+                title: "Delete Wallpaper"
+                text: `Delete "${targetTitle}" from disk? This cannot be undone.`
+                buttons: MessageDialog.Yes | MessageDialog.No
+
+                onAccepted: {
+                    if(!targetPath) return;
+                    const path = targetPath;
+                    const wid = targetWorkshopId;
+                    const wasSelected = wid && wid === cfg_WallpaperWorkShopId;
+                    pyext.delete_wallpaper(path, wid).then(res => {
+                        if(res && res.ok) {
+                            if(wasSelected) {
+                                cfg_WallpaperSource = "";
+                                cfg_WallpaperWorkShopId = "";
+                            }
+                            wpListModel.refresh();
+                        } else {
+                            console.error("delete failed:", res ? res.error : "no response");
+                        }
+                    }).catch(reason => console.error("delete error:", reason));
+                    targetPath = "";
+                    targetWorkshopId = "";
+                    targetTitle = "";
+                }
+                onRejected: {
+                    targetPath = "";
+                    targetWorkshopId = "";
+                    targetTitle = "";
                 }
             }
         }
@@ -460,7 +509,13 @@ RowLayout {
                             Kirigami.Action {
                                 icon.source: Qt.resolvedUrl('../../images/folder-outline.svg')
                                 tooltip: "Open Containing Folder"
-                                onTriggered: Qt.openUrlExternally(right_content.wpmodel.path) 
+                                onTriggered: Qt.openUrlExternally(right_content.wpmodel.path)
+                            },
+                            Kirigami.Action {
+                                icon.name: "edit-delete"
+                                tooltip: "Delete from disk"
+                                enabled: Boolean(right_content.wpmodel.path)
+                                onTriggered: picViewLoader.item.requestDelete(right_content.wpmodel)
                             }
                         ]
                     }


### PR DESCRIPTION
## Summary
- Adds a trash-icon `Kirigami.Action` on each grid thumbnail and on the right-side panel toolbar that deletes the wallpaper folder from disk.
- Wires a confirmation `MessageDialog` so the action is never destructive without user consent, and clears the active selection if the deleted wallpaper was the current one.
- Adds a `delete_wallpaper` RPC in `pyext.py` that refuses any path that isn't a directory containing `project.json`, and cleans up the per-wallpaper config file under `~/.config/wekde/wallpaper/`.

## Rationale
The picker previously only exposed "Open Workshop Link" / "Open Containing Folder". Users who accumulate large workshop collections had to leave the wallpaper picker (and open a file manager) just to remove unwanted items. This keeps the workflow inside the KCM.

## Test plan
- [ ] Open a Plasma desktop's wallpaper settings, pick "Wallpaper Engine", hover a thumbnail and click the trash icon — dialog shows the wallpaper's title.
- [ ] Confirm deletion and verify the folder is removed and the grid refreshes.
- [ ] Verify the right-panel trash action deletes the currently selected wallpaper and clears the selection.
- [ ] Pass a non-wallpaper path to the RPC manually and confirm it returns `{ok: false, error: "not a wallpaper folder"}` without touching the filesystem.