### PR TITLE
Add wallpaper rotation setting (0/90/180/270 degrees)

### DIFF
--- a/plugin/contents/config/main.xml
+++ b/plugin/contents/config/main.xml
@@ -26,6 +26,10 @@
       <label>Video display mode</label>
       <default>0</default>
     </entry>
+    <entry name="Rotation" type="Int">
+      <label>Wallpaper rotation in degrees</label>
+      <default>0</default>
+    </entry>
     <entry name="PauseMode" type="Int">
       <label>Video Pause mode</label>
       <default>0</default>

--- a/plugin/contents/ui/config.qml
+++ b/plugin/contents/ui/config.qml
@@ -32,6 +32,7 @@ ColumnLayout {
     property int    cfg_DisplayMode
     property int    cfg_PauseMode
     property int    cfg_VideoBackend
+    property alias  cfg_Rotation:            settingPage.cfg_Rotation
 
     property bool   cfg_PerOptChanged
 

--- a/plugin/contents/ui/main.qml
+++ b/plugin/contents/ui/main.qml
@@ -43,6 +43,7 @@ Rectangle {
     property bool   mute: get_opt_value('mute_audio', wallpaper.configuration.MuteAudio)
     property int    volume: get_opt_value('volume', wallpaper.configuration.Volume)
     property real    speed: get_opt_value('speed', wallpaper.configuration.Speed)
+    property int    rotationDeg: get_opt_value('rotation', wallpaper.configuration.Rotation)
 
     property bool   perOptChanged: wallpaper.configuration.PerOptChanged
     onPerOptChangedChanged: {
@@ -254,7 +255,11 @@ Rectangle {
     // main  
     Item { 
         id: backendLoader
-        anchors.fill: parent
+        readonly property bool _swapped: background.rotationDeg === 90 || background.rotationDeg === 270
+        width: _swapped ? parent.height : parent.width
+        height: _swapped ? parent.width : parent.height
+        anchors.centerIn: parent
+        rotation: background.rotationDeg
         property var item: null
 
         signal loaded

--- a/plugin/contents/ui/page/SettingPage.qml
+++ b/plugin/contents/ui/page/SettingPage.qml
@@ -27,6 +27,7 @@ Flickable {
 
     property alias cfg_PauseOnBatPower: chkbox_pauseOnBatPower.checked
     property alias cfg_PauseBatPercent: spin_pauseBatPercent.value
+    property int   cfg_Rotation
 
 
     Layout.fillWidth: true
@@ -142,6 +143,23 @@ Flickable {
                     textRole: "text"
                     onActivated: cfg_DisplayMode = Common.cbCurrentValue(this)
                     Component.onCompleted: currentIndex = Common.cbIndexOfValue(this, cfg_DisplayMode)
+                }
+            }
+            OptionItem {
+                text: 'Rotation'
+                text_color: Theme.textColor
+                icon: '../../images/window.svg'
+                actor: ComboBox {
+                    id: rotationCombo
+                    model: [
+                        { text: "0\u00B0 (Normal)",        value: 0 },
+                        { text: "90\u00B0 (Right)",        value: 90 },
+                        { text: "180\u00B0 (Upside down)", value: 180 },
+                        { text: "270\u00B0 (Left)",        value: 270 }
+                    ]
+                    textRole: "text"
+                    onActivated: cfg_Rotation = Common.cbCurrentValue(this)
+                    Component.onCompleted: currentIndex = Common.cbIndexOfValue(this, cfg_Rotation)
                 }
             }
 


### PR DESCRIPTION
## Summary
- Adds a global `Rotation` `kcfg` entry (default 0) and a ComboBox in the **Settings** page offering 0° / 90° / 180° / 270°.
- Applies the rotation to the `backendLoader` via QML's `rotation` property. Width and height are swapped for 90/270 so the rotated item still fills the parent, and it is anchored to the parent centre so it rotates about the correct point.
- Honours per-wallpaper overrides through `get_opt_value('rotation', ...)`, matching the existing pattern used for `display_mode`, `mute_audio`, etc.

## Rationale
Users with portrait-oriented monitors, or monitors physically mounted upside-down, previously had no way to display a Wallpaper Engine wallpaper in their screen's native orientation without pre-rotating the source material. Adding a rotation option avoids that workaround and works across all three backends (QtMultimedia, Mpv, Scene).

## Test plan
- [ ] With a landscape monitor, switch each rotation value and confirm the wallpaper fills the screen correctly at 0 / 90 / 180 / 270.
- [ ] Confirm the same on a portrait-oriented monitor (physical or logical).
- [ ] Change wallpaper type (image / video / scene) under a non-zero rotation and confirm the new backend loads rotated.
- [ ] Verify per-wallpaper `rotation` JSON overrides take effect when set via the existing per-wallpaper config flow.